### PR TITLE
Fix reading metadata when a Stream.Read doesn't read all requested bytes at once

### DIFF
--- a/src/TagLib/File.cs
+++ b/src/TagLib/File.cs
@@ -674,7 +674,7 @@ namespace TagLib {
 
 				read += count;
 				needed -= count;
-			} while(needed != 0 && count != 0);
+			} while(needed > 0 && count != 0);
 			
 			return new ByteVector (buffer, read);
 		}


### PR DESCRIPTION
https://bugzilla.gnome.org/show_bug.cgi?id=639817
