### PR TITLE
Fix for case where TagLibSharp edits the wrong udta box

### DIFF
--- a/src/TagLib/Mpeg4/File.cs
+++ b/src/TagLib/Mpeg4/File.cs
@@ -23,6 +23,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Linq;
 
 namespace TagLib.Mpeg4 {
 	/// <summary>
@@ -446,15 +447,13 @@ namespace TagLib.Mpeg4 {
 			if (udta_boxes.Count == 1)
 				return udta_boxes[0];	//Single udta - just return it
 
-			foreach (IsoUserDataBox udtaBox in udta_boxes) {
-				if (udtaBox.GetChild (BoxType.Meta)
-					!= null && udtaBox.GetChild (BoxType.Meta
-					).GetChild (BoxType.Ilst) != null)
+            // multiple udta : pick out the shallowest node which has an ILst tag
+		    var udtaBox = udta_boxes
+                .Where(box => box.GetChildRecursively(BoxType.Ilst) != null)
+                .OrderBy(box => box.ParentTree.Length)
+                .FirstOrDefault();
 
-					return udtaBox;
-			}
-
-			return null;
+			return udtaBox;
 		}
 
 		/// <summary>


### PR DESCRIPTION
I've come across an MP4 file which has multiple udta boxes each with a descendent Ilst tag. TagLib Sharp was picking the first of these, whereas iTunes and other tag editors seem to pick the one that is nearest to the root node of the tree. This is a fix to make Tag Lib Sharp pick the box at the highest level in the tree.
