### PR TITLE
Correction in VS solution(unable to compile from source) and invalid error handling in NonContainer.StarTag.ReadTag

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,7 +13,6 @@ configure
 *.config
 install-sh
 missing
-src/AssemblyInfo.cs
 *.pc
 *.zip
 tests/samples/tmp*
@@ -29,3 +28,7 @@ tests/*.dll
 tests/*.xml
 test-results
 .*.swp
+[oO]bj
+*.user
+*.pdb
+*.suo

--- a/src/AssemblyInfo.cs
+++ b/src/AssemblyInfo.cs
@@ -26,7 +26,7 @@ using System.Reflection;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 
-[assembly:AssemblyVersion("@ASSEMBLY_VERSION@")]
+[assembly:AssemblyVersion("2.0.4.0")]
 [assembly:AssemblyTitle ("TagLib#")]
 [assembly:AssemblyDescription ("A library for reading and writing audio metatags.")]
 [assembly:AssemblyCopyright ("Copyright (c) 2006-2007 Brian Nickel.  Copyright (c) 2009-2010 Other contributors")]

--- a/src/TagLib/NonContainer/StartTag.cs
+++ b/src/TagLib/NonContainer/StartTag.cs
@@ -264,19 +264,15 @@ namespace TagLib.NonContainer {
 			long end = start;
 			TagTypes type = ReadTagInfo (ref end);
 			TagLib.Tag tag = null;
-			
-			try {
-				switch (type)
-				{
-				case TagTypes.Ape:
-					tag = new TagLib.Ape.Tag (file, start);
-					break;
-				case TagTypes.Id3v2:
-					tag = new TagLib.Id3v2.Tag (file, start);
-					break;
-				}
-			} catch (CorruptFileException e) {
-                Console.Error.WriteLine ("taglib-sharp caught exception creating tag: {0}", e);
+
+			switch (type)
+			{
+			case TagTypes.Ape:
+				tag = new TagLib.Ape.Tag (file, start);
+				break;
+			case TagTypes.Id3v2:
+				tag = new TagLib.Id3v2.Tag (file, start);
+				break;
 			}
 
 			start = end;

--- a/src/taglib-sharp.csproj
+++ b/src/taglib-sharp.csproj
@@ -1,5 +1,5 @@
-<?xml version="1.0" encoding="utf-8"?>
-<Project DefaultTargets="Build" ToolsVersion="3.5" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
@@ -8,10 +8,30 @@
     <ProjectGuid>{6B143A39-C7B2-4743-9917-92262C60E9A6}</ProjectGuid>
     <OutputType>Library</OutputType>
     <RootNamespace>TagLib</RootNamespace>
-    <ApplicationIcon>.</ApplicationIcon>
+    <ApplicationIcon>
+    </ApplicationIcon>
     <AssemblyName>taglib-sharp</AssemblyName>
     <TargetFrameworkVersion>v3.5</TargetFrameworkVersion>
     <ReleaseVersion>2.0.4.0</ReleaseVersion>
+    <FileUpgradeFlags>
+    </FileUpgradeFlags>
+    <OldToolsVersion>3.5</OldToolsVersion>
+    <UpgradeBackupLocation />
+    <PublishUrl>publish\</PublishUrl>
+    <Install>true</Install>
+    <InstallFrom>Disk</InstallFrom>
+    <UpdateEnabled>false</UpdateEnabled>
+    <UpdateMode>Foreground</UpdateMode>
+    <UpdateInterval>7</UpdateInterval>
+    <UpdateIntervalUnits>Days</UpdateIntervalUnits>
+    <UpdatePeriodically>false</UpdatePeriodically>
+    <UpdateRequired>false</UpdateRequired>
+    <MapFileExtensions>true</MapFileExtensions>
+    <ApplicationRevision>0</ApplicationRevision>
+    <ApplicationVersion>1.0.0.%2a</ApplicationVersion>
+    <IsWebBootstrapper>false</IsWebBootstrapper>
+    <UseApplicationTrust>false</UseApplicationTrust>
+    <BootstrapperEnabled>true</BootstrapperEnabled>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -26,7 +46,8 @@
     <Execution>
       <Execution clr-version="Net_2_0" />
     </Execution>
-    <DefineConstants>HAVE_SHARPZIPLIB</DefineConstants>
+    <DefineConstants>
+    </DefineConstants>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>none</DebugType>
@@ -270,24 +291,34 @@
     <Compile Include="TagLib\Xmp\XmpTag.cs" />
   </ItemGroup>
   <ItemGroup>
-    <Folder Include="TagLib\NonContainer\" />
-    <Folder Include="TagLib\Ogg\Codecs\" />
-    <Folder Include="TagLib\Riff\" />
-    <Folder Include="TagLib\Id3v2\" />
-    <Folder Include="TagLib\Mpeg4\" />
-    <Folder Include="TagLib\Ogg\" />
+    <BootstrapperPackage Include="Microsoft.Net.Client.3.5">
+      <Visible>False</Visible>
+      <ProductName>.NET Framework 3.5 SP1 Client Profile</ProductName>
+      <Install>false</Install>
+    </BootstrapperPackage>
+    <BootstrapperPackage Include="Microsoft.Net.Framework.3.5.SP1">
+      <Visible>False</Visible>
+      <ProductName>.NET Framework 3.5 SP1</ProductName>
+      <Install>true</Install>
+    </BootstrapperPackage>
+    <BootstrapperPackage Include="Microsoft.Windows.Installer.3.1">
+      <Visible>False</Visible>
+      <ProductName>Windows Installer 3.1</ProductName>
+      <Install>true</Install>
+    </BootstrapperPackage>
   </ItemGroup>
   <ItemGroup>
     <Reference Include="System" />
     <Reference Include="System.Xml" />
     <Reference Include="System.Core" />
-    <Reference Include="ICSharpCode.SharpZipLib" />
   </ItemGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
   <ItemGroup>
+    <None Include="..\taglib-sharp.snk">
+      <Link>taglib-sharp.snk</Link>
+    </None>
     <None Include="AssemblyInfo.cs.in" />
     <None Include="policy.2.0.taglib-sharp.config.in" />
-    <None Include="taglib-sharp.snk" />
     <None Include="TagLib\TagLib.sources" />
   </ItemGroup>
 </Project>

--- a/taglib-sharp.sln
+++ b/taglib-sharp.sln
@@ -1,6 +1,6 @@
 ﻿
-Microsoft Visual Studio Solution File, Format Version 10.00
-# Visual Studio 2008
+Microsoft Visual Studio Solution File, Format Version 11.00
+# Visual Studio 2010
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "taglib-sharp", "src\taglib-sharp.csproj", "{6B143A39-C7B2-4743-9917-92262C60E9A6}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "tests", "tests\tests.csproj", "{4D1C6110-D6F2-496E-BD7E-E45B7217D458}"
@@ -19,6 +19,9 @@ Global
 		{4D1C6110-D6F2-496E-BD7E-E45B7217D458}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{4D1C6110-D6F2-496E-BD7E-E45B7217D458}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{4D1C6110-D6F2-496E-BD7E-E45B7217D458}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
 	EndGlobalSection
 	GlobalSection(MonoDevelopProperties) = preSolution
 		StartupItem = tests\tests.csproj

--- a/tests/tests.csproj
+++ b/tests/tests.csproj
@@ -1,5 +1,5 @@
-<?xml version="1.0" encoding="utf-8"?>
-<Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003" ToolsVersion="4.0">
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
@@ -10,6 +10,11 @@
     <RootNamespace>tests</RootNamespace>
     <AssemblyName>tests</AssemblyName>
     <ReleaseVersion>2.0.3.5</ReleaseVersion>
+    <TargetFrameworkVersion>v2.0</TargetFrameworkVersion>
+    <FileUpgradeFlags>
+    </FileUpgradeFlags>
+    <OldToolsVersion>2.0</OldToolsVersion>
+    <UpgradeBackupLocation />
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -50,7 +55,7 @@
     <Compile Include="fixtures\TagLib.Tests.FileFormats\IFormatTest.cs" />
     <Compile Include="fixtures\TagLib.Tests.FileFormats\JpegFormatTest.cs" />
     <Compile Include="fixtures\TagLib.Tests.FileFormats\M4aFormatTest.cs" />
-	<Compile Include="fixtures\TagLib.Tests.FileFormats\M4vFormatTest.cs" />
+    <Compile Include="fixtures\TagLib.Tests.FileFormats\M4vFormatTest.cs" />
     <Compile Include="fixtures\TagLib.Tests.FileFormats\MpcFormatTest.cs" />
     <Compile Include="fixtures\TagLib.Tests.FileFormats\OggFormatTest.cs" />
     <Compile Include="fixtures\TagLib.Tests.FileFormats\StandardTests.cs" />


### PR DESCRIPTION
VisualStudio was unable to compile TagLib# from source from GitHub(missing files, invalid configuration) so I decided to update it to fit my requirements(prepared AssemblyInfo.cs, link to snk in root directory). I'm not good in autoconf/make stuff, but I hope I didn't break anything.
Additionally, I removed reference to ICSharpCode.SharpZipLib from project and HAVE_SHARPZIPLIB constant from Debug compilation.
Tests project was untouched(only conversion).

NonContainer.StartTag.ReadTag was logging errors to console instead of throwing exceptions. Now it behave correctly.