### PR TITLE
Update src/TagLib/Xmp/XmpTag.cs

### DIFF
--- a/src/TagLib/Xmp/XmpTag.cs
+++ b/src/TagLib/Xmp/XmpTag.cs
@@ -255,6 +255,7 @@ namespace TagLib.Xmp
 		/// </param>
 		public XmpTag (string data, TagLib.File file)
 		{
+			data=data.Replace("\0",""); /*As I checked, the null values caused it to fail to create working xml values./*/
 			XmlDocument doc = new XmlDocument (NameTable);
 			doc.LoadXml (data);
 


### PR DESCRIPTION
Data variable for some reason has null values and it threw error
'.', hexadecimal value 0x00, is an invalid character. Line 38, position 1.
Which is fixed with this line edit. I am not sure if there could be other
places that needs this edit. Hope this helps others having same issue.

Thanks
Anuj P.
e10
