### PR TITLE
ID3 frame IDs containing 0 should be recognized as valid 

### DIFF
--- a/src/TagLib/Id3v2/FrameFactory.cs
+++ b/src/TagLib/Id3v2/FrameFactory.cs
@@ -141,7 +141,7 @@ namespace TagLib.Id3v2
 			foreach (byte b in header.FrameId) {
 				char c = (char) b;
 					if ((c < 'A' || c > 'Z') &&
-						(c < '1' || c > '9'))
+						(c < '0' || c > '9'))
 						return null;
 			}
 


### PR DESCRIPTION
(see http://www.id3.org/id3v2.4.0-frames section 4.3 as an example, where valid IDs said to be in the range W000 - WZZZ)

Ported bug fix from https://github.com/taglib/taglib/commit/e86e5f906b79b4eb0afaebd7f1b7b4f7234ea07c
