### PR TITLE
Fixed bug where the flag and version bytes where not being correctly wri...

### DIFF
--- a/src/TagLib/Mpeg4/AppleTag.cs
+++ b/src/TagLib/Mpeg4/AppleTag.cs
@@ -447,8 +447,8 @@ namespace TagLib.Mpeg4 {
 				data_box.Text = datastring;
 			} else {
 				//Create the new boxes, should use 1 for text as a flag
-				AppleAdditionalInfoBox amean_box = new AppleAdditionalInfoBox(BoxType.Mean);
-				AppleAdditionalInfoBox aname_box = new AppleAdditionalInfoBox(BoxType.Name);
+				AppleAdditionalInfoBox amean_box = new AppleAdditionalInfoBox(BoxType.Mean,0,1);
+				AppleAdditionalInfoBox aname_box = new AppleAdditionalInfoBox(BoxType.Name,0,1);
 				AppleDataBox adata_box = new AppleDataBox(BoxType.Data, 1);
 				amean_box.Text = meanstring;
 				aname_box.Text = namestring;

--- a/src/TagLib/Mpeg4/Boxes/AppleAdditionalInfoBox.cs
+++ b/src/TagLib/Mpeg4/Boxes/AppleAdditionalInfoBox.cs
@@ -29,7 +29,7 @@ namespace TagLib.Mpeg4 {
 	///    This class extends <see cref="Box" /> to provide an
 	///    implementation of an Apple AdditionalInfoBox.
 	/// </summary>
-	public class AppleAdditionalInfoBox : Box
+	public class AppleAdditionalInfoBox : FullBox
 	{
 		#region Private Fields
 		
@@ -65,11 +65,11 @@ namespace TagLib.Mpeg4 {
 		/// <exception cref="ArgumentNullException">
 		///    <paramref name="file" /> is <see langword="null" />.
 		/// </exception>
-		public AppleAdditionalInfoBox (BoxHeader header, TagLib.File file, IsoHandlerBox handler) : base (header, handler)
+		public AppleAdditionalInfoBox (BoxHeader header, TagLib.File file, IsoHandlerBox handler) : base (header, file, handler)
 		{
 			// We do not care what is in this custom data section
 			// see: https://developer.apple.com/library/mac/#documentation/QuickTime/QTFF/QTFFChap2/qtff2.html
-			Data = LoadData (file);
+            Data = file.ReadBlock(DataSize > 0 ? DataSize : 0); ;
 		}
 		
 		/// <summary>
@@ -79,7 +79,8 @@ namespace TagLib.Mpeg4 {
 		/// <param name="header"></param>
 		/// <param name="version"></param>
 		/// <param name="flags"></param>
-		public AppleAdditionalInfoBox (ByteVector header) : base (header)
+        public AppleAdditionalInfoBox(ByteVector header, byte version, uint flags)
+            : base(header, version, flags)
 		{
 		}
 		


### PR DESCRIPTION
The bug fix for this bug here (https://bugzilla.gnome.org/show_bug.cgi?id=658920) introduced a problem where the Version and Flags bytes (4 in total) required by the spec (https://developer.apple.com/library/mac/#documentation/QuickTime/QTFF/Metadata/Metadata.html#//apple_ref/doc/uid/TP40000939-CH1-SW1) were not written out in AppleAdditionalInfoBox resulting in dash tags which could not be read correctly.

This pull request fixes that problem, and hopefully preserves the originally bug fix (the test still passes).
