### PR TITLE
Fixed a bug where in certain AIFF files, the ID3 tag wasn't detected correctly, leading to a CorruptFileException.

### DIFF
--- a/src/TagLib/Aiff/File.cs
+++ b/src/TagLib/Aiff/File.cs
@@ -33,6 +33,7 @@ namespace TagLib.Aiff
 	///    using the AIFF file format.
 	/// </summary>
 	[SupportedMimeType("taglib/aif", "aif")]
+	[SupportedMimeType("taglib/aiff", "aiff")]
 	[SupportedMimeType("audio/x-aiff")]
 	[SupportedMimeType("audio/aiff")]
 	[SupportedMimeType("sound/aiff")]
@@ -92,6 +93,10 @@ namespace TagLib.Aiff
 		/// </value>
 		public static readonly ReadOnlyByteVector ID3Identifier = "ID3 ";
 
+        /// <summary>
+        ///    The identifier used to confirm that data within an AIFF ID3 chunk is really an ID3 tag.
+        /// </summary>
+        public static readonly ReadOnlyByteVector ID3TagHeader = new ReadOnlyByteVector(new byte[] {0x49, 0x44, 0x33});
 		#endregion
 
 		#region Public Constructors
@@ -437,7 +442,7 @@ namespace TagLib.Aiff
 			if (sound_chunk_pos == -1)
 			{
 				// The ID3 chunk appears before the Sound chunk
-				id3_chunk_pos = Find(ID3Identifier, 0);
+                                id3_chunk_pos = FindId3Chunk(0);
 			}
 
 			// Now let's look for the Sound chunk again
@@ -456,7 +461,7 @@ namespace TagLib.Aiff
 
 			if (id3_chunk_pos == -1)
 			{
-				id3_chunk_pos = Find(ID3Identifier, start_search_pos);
+				id3_chunk_pos = FindId3Chunk(start_search_pos);
 			}
 
 			if (id3_chunk_pos > -1)
@@ -477,5 +482,38 @@ namespace TagLib.Aiff
 		}
 
 		#endregion
+
+	    private long FindId3Chunk(long searchStartPos)
+	    {
+	        var searchPosition = searchStartPos;
+
+	        while (true)
+	        {
+                var chunkHeaderPosition = Find(ID3Identifier, searchPosition);
+	            if (chunkHeaderPosition < 0)
+	            {
+	                return chunkHeaderPosition;
+	            }
+
+                // a true ID3 block will have the ID3 header repeated 8 bytes after the chunk header
+                var id3HeaderPosition = Find(ID3TagHeader, chunkHeaderPosition + 8);
+	            if (id3HeaderPosition < 0)
+	            {
+	                return -1;
+	            }
+
+	            if (id3HeaderPosition == chunkHeaderPosition + 8)
+	            {
+                    return chunkHeaderPosition;
+	            }
+
+                // continue the search starting with the last position that matched
+                searchPosition = chunkHeaderPosition + 4;
+
+	            // if no true ID3 chunk is found, Find will return -1, and the loop will exit
+	        }
+	    }
 	}
+
+
 }


### PR DESCRIPTION
The problem was that, to find the ID3 tag, the reader is simply scanning the file for the byte sequence ID3. This can occur naturally within, say, the SSND chunk. The fix included here is to make sure that the ID3 sequence anticipated to be the chunk header is actually followed 8 bytes later by the expected ID3 sequence denoting the actual ID3 tag.
