### PR TITLE
Replace use of SharpZipLib with standard .NET DeflateStream

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -84,18 +84,6 @@ else
 	AM_CONDITIONAL(BUILD_DOCS, false)
 fi
 
-# checking for ICSharpCode.SharpZipLib.dll
-AC_MSG_CHECKING([Mono GAC for ICSharpCode.SharpZipLib.dll])
-if $GACUTIL -l | $GREP -q ICSharpCode.SharpZipLib; \
-	then \
-	AC_MSG_RESULT([found])
-	AM_CONDITIONAL(HAVE_SHARPZIPLIB, true)
-else
-	AC_MSG_RESULT([not found])
-	AM_CONDITIONAL(HAVE_SHARPZIPLIB, false)
-fi
-
-
 PKG_CHECK_MODULES(GNOME_SHARP, gnome-sharp-2.0, have_gnome_sharp=yes, have_gnome_sharp=no)
 if test "x$have_gnome_sharp" = "xyes"; then
 	AC_SUBST(GNOME_SHARP_LIBS)

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -10,10 +10,6 @@ DOCFILE =
 DOCFLAGS =
 endif
 
-if HAVE_SHARPZIPLIB
-    SHARPZIPLIB_FLAGS = -r:ICSharpCode.SharpZipLib.dll -define:HAVE_SHARPZIPLIB
-endif
-
 CSC = $(MCS) $(MCS_FLAGS) $(CSFLAGS)
 
 include $(srcdir)/TagLib/TagLib.sources
@@ -28,7 +24,7 @@ taglib_policy_configs = $(POLICIES:.dll=.config)
 taglib_policy_configs_in = $(POLICIES:.dll=.config.in)
 
 $(ASSEMBLY): $(TAGLIB_CSFILES) $(taglib_generated_sources) taglib-sharp.snk
-	$(CSC) /target:library $(LIBFLAGS) $(SHARPZIPLIB_FLAGS) $(DOCFLAGS) /define:SIGN /out:$@ $(TAGLIB_CSFILES) $(taglib_generated_sources)
+	$(CSC) /target:library $(LIBFLAGS) $(DOCFLAGS) /define:SIGN /out:$@ $(TAGLIB_CSFILES) $(taglib_generated_sources)
 
 policy.%.$(ASSEMBLY_NAME).dll: policy.%.$(ASSEMBLY_NAME).config
 	$(AL) /link:$< /out:$@ /keyfile:taglib-sharp.snk

--- a/src/taglib-sharp.csproj
+++ b/src/taglib-sharp.csproj
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
@@ -8,7 +8,8 @@
     <ProjectGuid>{6B143A39-C7B2-4743-9917-92262C60E9A6}</ProjectGuid>
     <OutputType>Library</OutputType>
     <RootNamespace>TagLib</RootNamespace>
-    <ApplicationIcon>.</ApplicationIcon>
+    <ApplicationIcon>
+    </ApplicationIcon>
     <AssemblyName>taglib-sharp</AssemblyName>
     <ReleaseVersion>2.0.4.0</ReleaseVersion>
     <TargetFrameworkVersion>v3.5</TargetFrameworkVersion>
@@ -26,7 +27,8 @@
     <Execution>
       <Execution clr-version="Net_2_0" />
     </Execution>
-    <DefineConstants>HAVE_SHARPZIPLIB</DefineConstants>
+    <DefineConstants>
+    </DefineConstants>
     <SignAssembly>true</SignAssembly>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
@@ -281,7 +283,6 @@
     <Reference Include="System" />
     <Reference Include="System.Xml" />
     <Reference Include="System.Core" />
-    <Reference Include="ICSharpCode.SharpZipLib" />
   </ItemGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
   <ItemGroup>

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -118,13 +118,9 @@ RAW_CSFILES = \
 	fixtures/TagLib.Tests.Images/RawLeicaDigilux2Test.cs \
 	fixtures/TagLib.Tests.Images/Rw2PanasonicG1Test.cs
 
-if HAVE_SHARPZIPLIB
-    SHARPZIPLIB_FLAGS = -r:ICSharpCode.SharpZipLib.dll -define:HAVE_SHARPZIPLIB
-endif
-
 
 $(ASSEMBLY): $(ASSEMBLY_CSFILES)
-	$(MCS) $(MCS_FLAGS) $(NUNIT_FLAGS) $(GNOME_SHARP_LIBS) $(SHARPZIPLIB_FLAGS) -out:$@ -target:library -r:$(top_builddir)/src/taglib-sharp.dll $(ASSEMBLY_CSFILES)
+	$(MCS) $(MCS_FLAGS) $(NUNIT_FLAGS) $(GNOME_SHARP_LIBS) -out:$@ -target:library -r:$(top_builddir)/src/taglib-sharp.dll $(ASSEMBLY_CSFILES)
 
 TAGLIB_ASM = ../src/taglib-sharp.dll
 

--- a/tests/fixtures/TagLib.Tests.Images/PngGimpPngcrushTest.cs
+++ b/tests/fixtures/TagLib.Tests.Images/PngGimpPngcrushTest.cs
@@ -20,14 +20,10 @@ namespace TagLib.Tests.Images
 
 				new PropertyModificationValidator<string> ("Comment", "Modified with pngcrush", "$% ¬ Test Comment äö "),
 				new PropertyModificationValidator<string> ("Creator", "Isaac Newton", "Albert Einstein"),
-#if HAVE_SHARPZIPLIB
 				new PropertyModificationValidator<string> ("Title", "Sunrise", "Eclipse"),
-#endif
 				new TagPropertyModificationValidator<string> ("Comment", "Modified with pngcrush", "$% ¬ Test Comment äö ", TagTypes.Png, true),
 				new TagPropertyModificationValidator<string> ("Creator", "Isaac Newton", "Albert Einstein", TagTypes.Png, true),
-#if HAVE_SHARPZIPLIB
 				new TagPropertyModificationValidator<string> ("Title", "Sunrise", "Eclipse", TagTypes.Png, true),
-#endif
 				new TagPropertyModificationValidator<string> ("Comment", null, "$% ¬ Test Comment äö ", TagTypes.XMP, false),
 				new TagPropertyModificationValidator<string> ("Creator", null, "Albert Einstein", TagTypes.XMP, false),
 				new TagPropertyModificationValidator<string> ("Title", null, "Eclipse", TagTypes.XMP, false),


### PR DESCRIPTION
SharpZipLib is used in only one place, to inflate zTXt chunks in PNG files.
DeflateStream can do the same job, without introducing a dependency
or complicating nuget packaging.
Since DeflateStream is a built-in .NET class, there is no longer a reason to
make zTXt support conditional, so I removed the conditional compilation.
Also removed a small defect in the VS project file which prevented compilation using VS.