### PR TITLE
The Channel Mode in a MPEG Audio Header

### DIFF
--- a/src/TagLib/Mpeg/AudioHeader.cs
+++ b/src/TagLib/Mpeg/AudioHeader.cs
@@ -592,7 +592,7 @@ namespace TagLib.Mpeg {
 		///    current instance.
 		/// </value>
 		public ChannelMode ChannelMode {
-			get {return (ChannelMode) ((flags >> 14) & 0x03);}
+			get {return (ChannelMode) ((flags >> 6) & 0x03);}
 		}
 		
 		/// <summary>


### PR DESCRIPTION
 ... is at position 7,6 and not 15,14 as in original code.

http://www.mp3-tech.org/programmer/frame_header.html