### PR TITLE
Replay gain support for Ape, Asf and Mpeg4 Files

### DIFF
--- a/src/TagLib/Ape/Tag.cs
+++ b/src/TagLib/Ape/Tag.cs
@@ -1419,6 +1419,188 @@ namespace TagLib.Ape {
 		}
 
 		/// <summary>
+		///    Gets and sets the ReplayGain track gain in dB.
+		/// </summary>
+		/// <value>
+		///    A <see cref="bool" /> value in dB for the track gain as
+		///    per the ReplayGain specification.
+		/// </value>
+		/// <remarks>
+		///    This property is implemented using the 
+		///    "REPLAYGAIN_TRACK_GAIN" field. Set the value to double.NaN
+		///    to clear the field.
+		/// </remarks>
+		public override double ReplayGainTrackGain
+		{
+			get
+			{
+				string text = GetItemAsString("REPLAYGAIN_TRACK_GAIN");
+				double value;
+
+				if (text == null)
+				{
+					return double.NaN;
+				}
+				if (text.ToLower(CultureInfo.InvariantCulture).EndsWith("db"))
+				{
+					text = text.Substring(0, text.Length - 2).Trim();
+				}
+
+				if (double.TryParse(text, NumberStyles.Float,
+					CultureInfo.InvariantCulture, out value))
+				{
+					return value;
+				}
+				return double.NaN;
+			}
+			set
+			{
+				if (double.IsNaN(value))
+				{
+					RemoveItem("REPLAYGAIN_TRACK_GAIN");
+				}
+				else
+				{
+					string text = value.ToString("0.00 dB",
+						CultureInfo.InvariantCulture);
+					SetValue("REPLAYGAIN_TRACK_GAIN", text);
+				}
+			}
+		}
+
+		/// <summary>
+		///    Gets and sets the ReplayGain track peak sample.
+		/// </summary>
+		/// <value>
+		///    A <see cref="bool" /> value for the track peak as per the
+		///    ReplayGain specification.
+		/// </value>
+		/// <remarks>
+		///    This property is implemented using the 
+		///    "REPLAYGAIN_TRACK_PEAK" field. Set the value to double.NaN
+		///    to clear the field.
+		/// </remarks>
+		public override double ReplayGainTrackPeak
+		{
+			get
+			{
+				string text;
+				double value;
+
+				if ((text = GetItemAsString("REPLAYGAIN_TRACK_PEAK")) !=
+					null && double.TryParse(text, NumberStyles.Float,
+						CultureInfo.InvariantCulture, out value))
+				{
+					return value;
+				}
+				return double.NaN;
+			}
+			set
+			{
+				if (double.IsNaN(value))
+				{
+					RemoveItem("REPLAYGAIN_TRACK_PEAK");
+				}
+				else
+				{
+					string text = value.ToString("0.000000", CultureInfo.InvariantCulture);
+					SetValue("REPLAYGAIN_TRACK_PEAK", text);
+				}
+			}
+		}
+
+		/// <summary>
+		///    Gets and sets the ReplayGain album gain in dB.
+		/// </summary>
+		/// <value>
+		///    A <see cref="bool" /> value in dB for the album gain as
+		///    per the ReplayGain specification.
+		/// </value>
+		/// <remarks>
+		///    This property is implemented using the 
+		///    "REPLAYGAIN_ALBUM_GAIN" field. Set the value to double.NaN
+		///    to clear the field.
+		/// </remarks>
+		public override double ReplayGainAlbumGain
+		{
+			get
+			{
+				string text = GetItemAsString("REPLAYGAIN_ALBUM_GAIN");
+				double value;
+
+				if (text == null)
+				{
+					return double.NaN;
+				}
+				if (text.ToLower(CultureInfo.InvariantCulture).EndsWith("db"))
+				{
+					text = text.Substring(0, text.Length - 2).Trim();
+				}
+
+				if (double.TryParse(text, NumberStyles.Float,
+					CultureInfo.InvariantCulture, out value))
+				{
+					return value;
+				}
+				return double.NaN;
+			}
+			set
+			{
+				if (double.IsNaN(value))
+				{
+					RemoveItem("REPLAYGAIN_ALBUM_GAIN");
+				}
+				else
+				{
+					string text = value.ToString("0.00 dB",
+						CultureInfo.InvariantCulture);
+					SetValue("REPLAYGAIN_ALBUM_GAIN", text);
+				}
+			}
+		}
+
+		/// <summary>
+		///    Gets and sets the ReplayGain album peak sample.
+		/// </summary>
+		/// <value>
+		///    A <see cref="bool" /> value for the album peak as per the
+		///    ReplayGain specification.
+		/// </value>
+		/// <remarks>
+		///    This property is implemented using the 
+		///    "REPLAYGAIN_ALBUM_PEAK" field. Set the value to double.NaN
+		///    to clear the field.
+		/// </remarks>
+		public override double ReplayGainAlbumPeak
+		{
+			get
+			{
+				string text;
+				double value;
+
+				if ((text = GetItemAsString("REPLAYGAIN_ALBUM_PEAK")) !=
+					null && double.TryParse(text, NumberStyles.Float,
+						CultureInfo.InvariantCulture, out value))
+				{
+					return value;
+				}
+				return double.NaN;
+			}
+			set
+			{
+				if (double.IsNaN(value))
+				{
+					RemoveItem("REPLAYGAIN_ALBUM_PEAK");
+				}
+				else
+				{
+					string text = value.ToString("0.000000", CultureInfo.InvariantCulture);
+					SetValue("REPLAYGAIN_ALBUM_PEAK", text);
+				}
+			}
+		}
+
+		/// <summary>
 		///    Gets and sets a collection of pictures associated with
 		///    the media represented by the current instance.
 		/// </summary>

--- a/src/TagLib/Asf/Tag.cs
+++ b/src/TagLib/Asf/Tag.cs
@@ -1325,7 +1325,7 @@ namespace TagLib.Asf {
 		{
 			get
 			{
-				string text = GetDescriptorString("REPLAYGAIN_TRACK_GAIN");
+				string text = GetDescriptorString("ReplayGain/Track");
 				double value;
 
 				if (text == null)
@@ -1348,13 +1348,13 @@ namespace TagLib.Asf {
 			{
 				if (double.IsNaN(value))
 				{
-					RemoveDescriptors("REPLAYGAIN_TRACK_GAIN");
+					RemoveDescriptors("ReplayGain/Track");
 				}
 				else
 				{
 					string text = value.ToString("0.00 dB",
 						CultureInfo.InvariantCulture);
-					SetDescriptorString("REPLAYGAIN_TRACK_GAIN", text);
+					SetDescriptorString(text, "ReplayGain/Track");
 				}
 			}
 		}
@@ -1378,7 +1378,7 @@ namespace TagLib.Asf {
 				string text;
 				double value;
 
-				if ((text = GetDescriptorString("REPLAYGAIN_TRACK_PEAK")) !=
+				if ((text = GetDescriptorString("ReplayGain/Track Peak")) !=
 					null && double.TryParse(text, NumberStyles.Float,
 						CultureInfo.InvariantCulture, out value))
 				{
@@ -1390,12 +1390,12 @@ namespace TagLib.Asf {
 			{
 				if (double.IsNaN(value))
 				{
-					RemoveDescriptors("REPLAYGAIN_TRACK_PEAK");
+					RemoveDescriptors("ReplayGain/Track Peak");
 				}
 				else
 				{
 					string text = value.ToString("0.000000", CultureInfo.InvariantCulture);
-					SetDescriptorString("REPLAYGAIN_TRACK_PEAK", text);
+					SetDescriptorString(text, "ReplayGain/Track Peak");
 				}
 			}
 		}
@@ -1416,7 +1416,7 @@ namespace TagLib.Asf {
 		{
 			get
 			{
-				string text = GetDescriptorString("REPLAYGAIN_ALBUM_GAIN");
+				string text = GetDescriptorString("ReplayGain/Album");
 				double value;
 
 				if (text == null)
@@ -1439,13 +1439,13 @@ namespace TagLib.Asf {
 			{
 				if (double.IsNaN(value))
 				{
-					RemoveDescriptors("REPLAYGAIN_ALBUM_GAIN");
+					RemoveDescriptors("ReplayGain/Album");
 				}
 				else
 				{
 					string text = value.ToString("0.00 dB",
 						CultureInfo.InvariantCulture);
-					SetDescriptorString("REPLAYGAIN_ALBUM_GAIN", text);
+					SetDescriptorString(text, "ReplayGain/Album");
 				}
 			}
 		}
@@ -1469,7 +1469,7 @@ namespace TagLib.Asf {
 				string text;
 				double value;
 
-				if ((text = GetDescriptorString("REPLAYGAIN_ALBUM_PEAK")) !=
+				if ((text = GetDescriptorString("ReplayGain/Album Peak")) !=
 					null && double.TryParse(text, NumberStyles.Float,
 						CultureInfo.InvariantCulture, out value))
 				{
@@ -1481,12 +1481,12 @@ namespace TagLib.Asf {
 			{
 				if (double.IsNaN(value))
 				{
-					RemoveDescriptors("REPLAYGAIN_ALBUM_PEAK");
+					RemoveDescriptors("ReplayGain/Album Peak");
 				}
 				else
 				{
 					string text = value.ToString("0.000000", CultureInfo.InvariantCulture);
-					SetDescriptorString("REPLAYGAIN_ALBUM_PEAK", text);
+					SetDescriptorString(text, "ReplayGain/Album Peak");
 				}
 			}
 		}

--- a/src/TagLib/Asf/Tag.cs
+++ b/src/TagLib/Asf/Tag.cs
@@ -1310,6 +1310,188 @@ namespace TagLib.Asf {
 		}
 
 		/// <summary>
+		///    Gets and sets the ReplayGain track gain in dB.
+		/// </summary>
+		/// <value>
+		///    A <see cref="bool" /> value in dB for the track gain as
+		///    per the ReplayGain specification.
+		/// </value>
+		/// <remarks>
+		///    This property is implemented using the 
+		///    "REPLAYGAIN_TRACK_GAIN" field. Set the value to double.NaN
+		///    to clear the field.
+		/// </remarks>
+		public override double ReplayGainTrackGain
+		{
+			get
+			{
+				string text = GetDescriptorString("REPLAYGAIN_TRACK_GAIN");
+				double value;
+
+				if (text == null)
+				{
+					return double.NaN;
+				}
+				if (text.ToLower(CultureInfo.InvariantCulture).EndsWith("db"))
+				{
+					text = text.Substring(0, text.Length - 2).Trim();
+				}
+
+				if (double.TryParse(text, NumberStyles.Float,
+					CultureInfo.InvariantCulture, out value))
+				{
+					return value;
+				}
+				return double.NaN;
+			}
+			set
+			{
+				if (double.IsNaN(value))
+				{
+					RemoveDescriptors("REPLAYGAIN_TRACK_GAIN");
+				}
+				else
+				{
+					string text = value.ToString("0.00 dB",
+						CultureInfo.InvariantCulture);
+					SetDescriptorString("REPLAYGAIN_TRACK_GAIN", text);
+				}
+			}
+		}
+
+		/// <summary>
+		///    Gets and sets the ReplayGain track peak sample.
+		/// </summary>
+		/// <value>
+		///    A <see cref="bool" /> value for the track peak as per the
+		///    ReplayGain specification.
+		/// </value>
+		/// <remarks>
+		///    This property is implemented using the 
+		///    "REPLAYGAIN_TRACK_PEAK" field. Set the value to double.NaN
+		///    to clear the field.
+		/// </remarks>
+		public override double ReplayGainTrackPeak
+		{
+			get
+			{
+				string text;
+				double value;
+
+				if ((text = GetDescriptorString("REPLAYGAIN_TRACK_PEAK")) !=
+					null && double.TryParse(text, NumberStyles.Float,
+						CultureInfo.InvariantCulture, out value))
+				{
+					return value;
+				}
+				return double.NaN;
+			}
+			set
+			{
+				if (double.IsNaN(value))
+				{
+					RemoveDescriptors("REPLAYGAIN_TRACK_PEAK");
+				}
+				else
+				{
+					string text = value.ToString("0.000000", CultureInfo.InvariantCulture);
+					SetDescriptorString("REPLAYGAIN_TRACK_PEAK", text);
+				}
+			}
+		}
+
+		/// <summary>
+		///    Gets and sets the ReplayGain album gain in dB.
+		/// </summary>
+		/// <value>
+		///    A <see cref="bool" /> value in dB for the album gain as
+		///    per the ReplayGain specification.
+		/// </value>
+		/// <remarks>
+		///    This property is implemented using the 
+		///    "REPLAYGAIN_ALBUM_GAIN" field. Set the value to double.NaN
+		///    to clear the field.
+		/// </remarks>
+		public override double ReplayGainAlbumGain
+		{
+			get
+			{
+				string text = GetDescriptorString("REPLAYGAIN_ALBUM_GAIN");
+				double value;
+
+				if (text == null)
+				{
+					return double.NaN;
+				}
+				if (text.ToLower(CultureInfo.InvariantCulture).EndsWith("db"))
+				{
+					text = text.Substring(0, text.Length - 2).Trim();
+				}
+
+				if (double.TryParse(text, NumberStyles.Float,
+					CultureInfo.InvariantCulture, out value))
+				{
+					return value;
+				}
+				return double.NaN;
+			}
+			set
+			{
+				if (double.IsNaN(value))
+				{
+					RemoveDescriptors("REPLAYGAIN_ALBUM_GAIN");
+				}
+				else
+				{
+					string text = value.ToString("0.00 dB",
+						CultureInfo.InvariantCulture);
+					SetDescriptorString("REPLAYGAIN_ALBUM_GAIN", text);
+				}
+			}
+		}
+
+		/// <summary>
+		///    Gets and sets the ReplayGain album peak sample.
+		/// </summary>
+		/// <value>
+		///    A <see cref="bool" /> value for the album peak as per the
+		///    ReplayGain specification.
+		/// </value>
+		/// <remarks>
+		///    This property is implemented using the 
+		///    "REPLAYGAIN_ALBUM_PEAK" field. Set the value to double.NaN
+		///    to clear the field.
+		/// </remarks>
+		public override double ReplayGainAlbumPeak
+		{
+			get
+			{
+				string text;
+				double value;
+
+				if ((text = GetDescriptorString("REPLAYGAIN_ALBUM_PEAK")) !=
+					null && double.TryParse(text, NumberStyles.Float,
+						CultureInfo.InvariantCulture, out value))
+				{
+					return value;
+				}
+				return double.NaN;
+			}
+			set
+			{
+				if (double.IsNaN(value))
+				{
+					RemoveDescriptors("REPLAYGAIN_ALBUM_PEAK");
+				}
+				else
+				{
+					string text = value.ToString("0.000000", CultureInfo.InvariantCulture);
+					SetDescriptorString("REPLAYGAIN_ALBUM_PEAK", text);
+				}
+			}
+		}
+
+		/// <summary>
 		///    Gets and sets a collection of pictures associated with
 		///    the media represented by the current instance.
 		/// </summary>

--- a/src/TagLib/Mpeg4/AppleTag.cs
+++ b/src/TagLib/Mpeg4/AppleTag.cs
@@ -1360,6 +1360,160 @@ namespace TagLib.Mpeg4 {
 			set {SetDashBox("com.apple.iTunes", "MusicBrainz Album Release Country",value);}
 		}
 
+    /// <summary>
+    ///    Gets and sets the ReplayGain Track Value of the media represented by
+    ///    the current instance.
+    /// </summary>
+    /// <value>
+    ///    A <see cref="double" /> containing the ReplayGain Track Value of the
+    ///    media represented by the current instance or an empty
+    ///    array if no value is present.
+    /// </value>
+    /// <remarks>
+    ///    This property is implemented using the "dash"/"----" box type.
+    /// </remarks>
+    public override double ReplayGainTrackGain
+    {
+			get
+			{
+				string text = GetDashBox("com.apple.iTunes", "REPLAYGAIN_TRACK_GAIN");
+				double value;
+
+				if (text == null)
+				{
+					return double.NaN;
+				}
+				if (text.ToLower(CultureInfo.InvariantCulture).EndsWith("db"))
+				{
+					text = text.Substring(0, text.Length - 2).Trim();
+				}
+
+				if (double.TryParse(text, NumberStyles.Float,
+					CultureInfo.InvariantCulture, out value))
+				{
+					return value;
+				}
+				return double.NaN;
+			}
+			set
+			{
+				string text = value.ToString("0.00 dB",
+					CultureInfo.InvariantCulture);
+				SetDashBox("com.apple.iTunes", "REPLAYGAIN_TRACK_GAIN", text);
+			}
+		}
+
+    /// <summary>
+    ///    Gets and sets the ReplayGain Peak Value of the media represented by
+    ///    the current instance.
+    /// </summary>
+    /// <value>
+    ///    A <see cref="double" /> containing the ReplayGain Peak Value of the
+    ///    media represented by the current instance or an empty
+    ///    array if no value is present.
+    /// </value>
+    /// <remarks>
+    ///    This property is implemented using the "dash"/"----" box type.
+    /// </remarks>
+    public override double ReplayGainTrackPeak
+    {
+			get
+			{
+				string text;
+				double value;
+
+				if ((text = GetDashBox("com.apple.iTunes", "REPLAYGAIN_TRACK_PEAK")) !=
+					null && double.TryParse(text, NumberStyles.Float,
+						CultureInfo.InvariantCulture, out value))
+				{
+					return value;
+				}
+				return double.NaN;
+			}
+			set
+			{
+				string text = value.ToString("0.000000", CultureInfo.InvariantCulture);
+				SetDashBox("com.apple.iTunes", "REPLAYGAIN_TRACK_PEAK", text);
+			}
+		}
+
+    /// <summary>
+    ///    Gets and sets the ReplayGain Album Value of the media represented by
+    ///    the current instance.
+    /// </summary>
+    /// <value>
+    ///    A <see cref="double" /> containing the ReplayGain Album Value of the
+    ///    media represented by the current instance or an empty
+    ///    array if no value is present.
+    /// </value>
+    /// <remarks>
+    ///    This property is implemented using the "dash"/"----" box type.
+    /// </remarks>
+    public override double ReplayGainAlbumGain
+    {
+			get
+			{
+				string text = GetDashBox("com.apple.iTunes", "REPLAYGAIN_ALBUM_GAIN");
+				double value;
+
+				if (text == null)
+				{
+					return double.NaN;
+				}
+				if (text.ToLower(CultureInfo.InvariantCulture).EndsWith("db"))
+				{
+					text = text.Substring(0, text.Length - 2).Trim();
+				}
+
+				if (double.TryParse(text, NumberStyles.Float,
+					CultureInfo.InvariantCulture, out value))
+				{
+					return value;
+				}
+				return double.NaN;
+			}
+			set
+			{
+				string text = value.ToString("0.00 dB",
+					CultureInfo.InvariantCulture);
+				SetDashBox("com.apple.iTunes", "REPLAYGAIN_ALBUM_GAIN", text);
+			}
+		}
+
+    /// <summary>
+    ///    Gets and sets the ReplayGain Album Peak Value of the media represented by
+    ///    the current instance.
+    /// </summary>
+    /// <value>
+    ///    A <see cref="double" /> containing the ReplayGain Album Peak Value of the
+    ///    media represented by the current instance or an empty
+    ///    array if no value is present.
+    /// </value>
+    /// <remarks>
+    ///    This property is implemented using the "dash"/"----" box type.
+    /// </remarks>
+    public override double ReplayGainAlbumPeak
+    {
+			get
+			{
+				string text;
+				double value;
+
+				if ((text = GetDashBox("com.apple.iTunes", "REPLAYGAIN_ALBUM_PEAK")) !=
+					null && double.TryParse(text, NumberStyles.Float,
+						CultureInfo.InvariantCulture, out value))
+				{
+					return value;
+				}
+				return double.NaN;
+			}
+			set
+			{
+				string text = value.ToString("0.000000", CultureInfo.InvariantCulture);
+				SetDashBox("com.apple.iTunes", "REPLAYGAIN_ALBUM_PEAK", text);
+			}
+		}
+
 		/// <summary>
 		///    Gets and sets a collection of pictures associated with
 		///    the media represented by the current instance.

--- a/src/TagLib/Ogg/GroupedComment.cs
+++ b/src/TagLib/Ogg/GroupedComment.cs
@@ -1208,6 +1208,154 @@ namespace TagLib.Ogg
 			set {if (tags.Count > 0) tags [0].MusicBrainzReleaseCountry = value;}
 		}
 
+    /// <summary>
+    ///    Gets and sets the ReplayGain Track Value of the media represented by
+    ///    the current instance.
+    /// </summary>
+    /// <value>
+    ///    A <see cref="double" /> containing the ReplayGain Track Value of the
+    ///    media represented by the current instance or an empty
+    ///    array if no value is present.
+    /// </value>
+    /// <remarks>
+    ///    <para>When getting the value, the child tags are looped
+    ///    through in order and the first non-<see langword="null" />
+    ///    and non-empty value is returned.</para>
+    ///    <para>When setting the value, it is stored in the first
+    ///    comment.</para>
+    /// </remarks>
+    /// <seealso cref="Tag.ReplayGainTrackGain" />
+    public override double ReplayGainTrackGain
+    {
+      get
+      {
+        foreach (XiphComment tag in tags)
+        {
+          if (tag == null)
+            continue;
+
+          double value = tag.ReplayGainTrackGain;
+
+          if (!double.IsNaN(value))
+            return value;
+        }
+
+				return double.NaN;
+      }
+      set { if (tags.Count > 0) tags[0].ReplayGainTrackGain = value; }
+    }
+
+    /// <summary>
+    ///    Gets and sets the ReplayGain Peak Value of the media represented by
+    ///    the current instance.
+    /// </summary>
+    /// <value>
+    ///    A <see cref="double" /> containing the ReplayGain Peak Value of the
+    ///    media represented by the current instance or an empty
+    ///    array if no value is present.
+    /// </value>
+    /// <remarks>
+    ///    <para>When getting the value, the child tags are looped
+    ///    through in order and the first non-<see langword="null" />
+    ///    and non-empty value is returned.</para>
+    ///    <para>When setting the value, it is stored in the first
+    ///    comment.</para>
+    /// </remarks>
+    /// <seealso cref="Tag.ReplayGainTrackPeak" />
+    public override double ReplayGainTrackPeak
+    {
+      get
+      {
+        foreach (XiphComment tag in tags)
+        {
+          if (tag == null)
+            continue;
+
+          double value = tag.ReplayGainTrackPeak;
+
+          if (!double.IsNaN(value))
+            return value;
+        }
+
+        return double.NaN;
+      }
+      set { if (tags.Count > 0) tags[0].ReplayGainTrackPeak = value; }
+    }
+
+    /// <summary>
+    ///    Gets and sets the ReplayGain Album Value of the media represented by
+    ///    the current instance.
+    /// </summary>
+    /// <value>
+    ///    A <see cref="double" /> containing the ReplayGain Album Value of the
+    ///    media represented by the current instance or an empty
+    ///    array if no value is present.
+    /// </value>
+    /// <remarks>
+    ///    <para>When getting the value, the child tags are looped
+    ///    through in order and the first non-<see langword="null" />
+    ///    and non-empty value is returned.</para>
+    ///    <para>When setting the value, it is stored in the first
+    ///    comment.</para>
+    /// </remarks>
+    /// <seealso cref="Tag.ReplayGainAlbumGain" />
+    public override double ReplayGainAlbumGain
+    {
+      get
+      {
+        foreach (XiphComment tag in tags)
+        {
+          if (tag == null)
+            continue;
+
+          double value = tag.ReplayGainAlbumGain;
+
+          if (!double.IsNaN(value))
+            return value;
+        }
+
+        return double.NaN;
+      }
+      set { if (tags.Count > 0) tags[0].ReplayGainAlbumGain = value; }
+    }
+
+    /// <summary>
+    ///    Gets and sets the ReplayGain Album Peak Value of the media represented by
+    ///    the current instance.
+    /// </summary>
+    /// <value>
+    ///    A <see cref="double" /> containing the ReplayGain Album Peak Value of the
+    ///    media represented by the current instance or an empty
+    ///    array if no value is present.
+    /// </value>
+    /// <remarks>
+    ///    <para>When getting the value, the child tags are looped
+    ///    through in order and the first non-<see langword="null" />
+    ///    and non-empty value is returned.</para>
+    ///    <para>When setting the value, it is stored in the first
+    ///    comment.</para>
+    /// </remarks>
+    /// <seealso cref="Tag.ReplayGainAlbumPeak" />
+    public override double ReplayGainAlbumPeak
+    {
+      get
+      {
+        foreach (XiphComment tag in tags)
+        {
+          if (tag == null)
+            continue;
+
+          double value = tag.ReplayGainAlbumPeak;
+
+          if (!double.IsNaN(value))
+            return value;
+        }
+
+        return double.NaN;
+      }
+      set { if (tags.Count > 0) tags[0].ReplayGainAlbumPeak = value; }
+    }
+
 		/// <summary>
 		///    Gets and sets a collection of pictures associated with
 		///    the media represented by the current instance.

--- a/tests/fixtures/TagLib.Tests.FileFormats/AiffFormatTest.cs
+++ b/tests/fixtures/TagLib.Tests.FileFormats/AiffFormatTest.cs
@@ -48,6 +48,12 @@ namespace TagLib.Tests.FileFormats
 		}
 
 		[Test]
+		public void WriteExtendedTags()
+		{
+			ExtendedTests.WriteExtendedTags(sample_file, tmp_file);
+		}
+
+		[Test]
 		public void TestCorruptionResistance()
 		{
 			StandardTests.TestCorruptionResistance(corrupt_file);

--- a/tests/fixtures/TagLib.Tests.FileFormats/AsfFormatTest.cs
+++ b/tests/fixtures/TagLib.Tests.FileFormats/AsfFormatTest.cs
@@ -41,8 +41,14 @@ namespace TagLib.Tests.FileFormats
         {
             StandardTests.WriteStandardTags (sample_file, tmp_file);
         }
-        
-        [Test]
+
+				[Test]
+				public void WriteExtendedTags()
+				{
+					ExtendedTests.WriteExtendedTags(sample_file, tmp_file);
+				}
+
+				[Test]
         public void TestCorruptionResistance()
         {
             StandardTests.TestCorruptionResistance ("samples/corrupt/a.wma");

--- a/tests/fixtures/TagLib.Tests.FileFormats/AsfFormatTest.cs
+++ b/tests/fixtures/TagLib.Tests.FileFormats/AsfFormatTest.cs
@@ -42,13 +42,13 @@ namespace TagLib.Tests.FileFormats
             StandardTests.WriteStandardTags (sample_file, tmp_file);
         }
 
-				[Test]
-				public void WriteExtendedTags()
-				{
-					ExtendedTests.WriteExtendedTags(sample_file, tmp_file);
-				}
+		[Test]
+		public void WriteExtendedTags()
+		{
+			ExtendedTests.WriteExtendedTags(sample_file, tmp_file);
+		}
 
-				[Test]
+		[Test]
         public void TestCorruptionResistance()
         {
             StandardTests.TestCorruptionResistance ("samples/corrupt/a.wma");

--- a/tests/fixtures/TagLib.Tests.FileFormats/ExtendedTests.cs
+++ b/tests/fixtures/TagLib.Tests.FileFormats/ExtendedTests.cs
@@ -21,8 +21,8 @@ namespace TagLib.Tests.FileFormats
                 tmp = File.Create (tmp_file);
                 CheckTags (tmp.Tag);
             } finally {
-//                if (System.IO.File.Exists (tmp_file))
-//                    System.IO.File.Delete (tmp_file);
+                if (System.IO.File.Exists (tmp_file))
+                    System.IO.File.Delete (tmp_file);
             }
         }
         

--- a/tests/fixtures/TagLib.Tests.FileFormats/ExtendedTests.cs
+++ b/tests/fixtures/TagLib.Tests.FileFormats/ExtendedTests.cs
@@ -1,0 +1,57 @@
+using System;
+using NUnit.Framework;
+using TagLib;
+
+namespace TagLib.Tests.FileFormats
+{   
+    public static class ExtendedTests
+    {      
+        public static void WriteExtendedTags (string sample_file, string tmp_file)
+        {
+            if (System.IO.File.Exists (tmp_file))
+                System.IO.File.Delete (tmp_file);
+            
+            try {
+                System.IO.File.Copy(sample_file, tmp_file);
+                
+                File tmp = File.Create (tmp_file);
+                SetTags (tmp.Tag);
+                tmp.Save ();
+                
+                tmp = File.Create (tmp_file);
+                CheckTags (tmp.Tag);
+            } finally {
+//                if (System.IO.File.Exists (tmp_file))
+//                    System.IO.File.Delete (tmp_file);
+            }
+        }
+        
+        public static void SetTags (Tag tag)
+        {
+						tag.ReplayGainTrackGain = -10.28;
+						tag.ReplayGainTrackPeak = 0.999969;
+						tag.ReplayGainAlbumGain = -9.98;
+						tag.ReplayGainAlbumPeak = 0.999980;
+				
+        }
+        
+        public static void CheckTags (Tag tag)
+        {
+            Assert.AreEqual (-10.28, tag.ReplayGainTrackGain);
+						Assert.AreEqual(0.999969, tag.ReplayGainTrackPeak);
+						Assert.AreEqual(-9.98, tag.ReplayGainAlbumGain);
+						Assert.AreEqual(0.999980, tag.ReplayGainAlbumPeak);
+				}
+        
+        public static void TestCorruptionResistance (string path)
+        {
+            try {
+                File.Create (path);
+            } catch(CorruptFileException) {
+            } catch(NullReferenceException e) {
+                throw e;
+            } catch {
+            }
+        }
+    }
+}

--- a/tests/fixtures/TagLib.Tests.FileFormats/Id3V2FormatTest.cs
+++ b/tests/fixtures/TagLib.Tests.FileFormats/Id3V2FormatTest.cs
@@ -45,13 +45,13 @@ namespace TagLib.Tests.FileFormats
             StandardTests.WriteStandardTags (sample_file, tmp_file);
         }
 
-				[Test]
-				public void WriteExtendedTags()
-				{
-					ExtendedTests.WriteExtendedTags(sample_file, tmp_file);
-				}
+		[Test]
+		public void WriteExtendedTags()
+		{
+			ExtendedTests.WriteExtendedTags(sample_file, tmp_file);
+		}
 
-				[Test] // http://bugzilla.gnome.org/show_bug.cgi?id=558123
+		[Test] // http://bugzilla.gnome.org/show_bug.cgi?id=558123
         public void TestTruncateOnNull ()
         {
             if (System.IO.File.Exists (tmp_file)) {

--- a/tests/fixtures/TagLib.Tests.FileFormats/Id3V2FormatTest.cs
+++ b/tests/fixtures/TagLib.Tests.FileFormats/Id3V2FormatTest.cs
@@ -44,8 +44,14 @@ namespace TagLib.Tests.FileFormats
         {
             StandardTests.WriteStandardTags (sample_file, tmp_file);
         }
-        
-        [Test] // http://bugzilla.gnome.org/show_bug.cgi?id=558123
+
+				[Test]
+				public void WriteExtendedTags()
+				{
+					ExtendedTests.WriteExtendedTags(sample_file, tmp_file);
+				}
+
+				[Test] // http://bugzilla.gnome.org/show_bug.cgi?id=558123
         public void TestTruncateOnNull ()
         {
             if (System.IO.File.Exists (tmp_file)) {

--- a/tests/fixtures/TagLib.Tests.FileFormats/M4aFormatTest.cs
+++ b/tests/fixtures/TagLib.Tests.FileFormats/M4aFormatTest.cs
@@ -72,7 +72,7 @@ namespace TagLib.Tests.FileFormats
             var first = file.UdtaBoxes [0];
             Assert.AreEqual (1, first.Children.Count (), "#2");
 
-            //Assert.IsInstanceOfType (typeof (AppleAdditionalInfoBox), first.Children.First ());
+            Assert.IsInstanceOfType (typeof (AppleAdditionalInfoBox), first.Children.First ());
             var child = (AppleAdditionalInfoBox) first.Children.First ();
             Assert.AreEqual ((ReadOnlyByteVector)"name", child.BoxType, "#3");
             Assert.AreEqual (0 , child.Data.Count, "#4");

--- a/tests/fixtures/TagLib.Tests.FileFormats/M4aFormatTest.cs
+++ b/tests/fixtures/TagLib.Tests.FileFormats/M4aFormatTest.cs
@@ -72,7 +72,7 @@ namespace TagLib.Tests.FileFormats
             var first = file.UdtaBoxes [0];
             Assert.AreEqual (1, first.Children.Count (), "#2");
 
-            Assert.IsInstanceOfType (typeof (AppleAdditionalInfoBox), first.Children.First ());
+            //Assert.IsInstanceOfType (typeof (AppleAdditionalInfoBox), first.Children.First ());
             var child = (AppleAdditionalInfoBox) first.Children.First ();
             Assert.AreEqual ((ReadOnlyByteVector)"name", child.BoxType, "#3");
             Assert.AreEqual (0 , child.Data.Count, "#4");
@@ -102,8 +102,14 @@ namespace TagLib.Tests.FileFormats
         {
             StandardTests.WriteStandardTags (sample_file, tmp_file);
         }
-        
-        [Test]
+
+				[Test]
+				public void WriteExtendedTags()
+				{
+					ExtendedTests.WriteExtendedTags(sample_file, tmp_file);
+				}
+
+				[Test]
         public void TestCorruptionResistance()
         {
             StandardTests.TestCorruptionResistance ("samples/corrupt/a.m4a");

--- a/tests/fixtures/TagLib.Tests.FileFormats/OggFormatTest.cs
+++ b/tests/fixtures/TagLib.Tests.FileFormats/OggFormatTest.cs
@@ -41,8 +41,14 @@ namespace TagLib.Tests.FileFormats
         {
             StandardTests.WriteStandardTags (sample_file, tmp_file);
         }
-        
-        [Test]
+
+				[Test]
+				public void WriteExtendedTags()
+				{
+					ExtendedTests.WriteExtendedTags(sample_file, tmp_file);
+				}
+
+				[Test]
         public void TestCorruptionResistance()
         {
             StandardTests.TestCorruptionResistance ("samples/corrupt/a.ogg");

--- a/tests/fixtures/TagLib.Tests.FileFormats/OpusFormatTest.cs
+++ b/tests/fixtures/TagLib.Tests.FileFormats/OpusFormatTest.cs
@@ -42,7 +42,13 @@ namespace TagLib.Tests.FileFormats
             StandardTests.WriteStandardTags (sample_file, tmp_file);
         }
 
-        [Test]
+				[Test]
+				public void WriteExtendedTags()
+				{
+					ExtendedTests.WriteExtendedTags(sample_file, tmp_file);
+				}
+
+				[Test]
         public void TestCorruptionResistance()
         {
             StandardTests.TestCorruptionResistance ("samples/corrupt/a.opus");

--- a/tests/tests.csproj
+++ b/tests/tests.csproj
@@ -13,6 +13,7 @@
     <SignAssembly>True</SignAssembly>
     <AssemblyOriginatorKeyFile>..\taglib-sharp.snk</AssemblyOriginatorKeyFile>
     <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <TargetFrameworkProfile />
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>True</DebugSymbols>
@@ -22,6 +23,7 @@
     <DefineConstants>DEBUG</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
+    <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>none</DebugType>
@@ -29,6 +31,7 @@
     <OutputPath>.</OutputPath>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
+    <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="System" />
@@ -66,6 +69,7 @@
     <Compile Include="fixtures\TagLib.Tests.FileFormats\MpcFormatTest.cs" />
     <Compile Include="fixtures\TagLib.Tests.FileFormats\OggFormatTest.cs" />
     <Compile Include="fixtures\TagLib.Tests.FileFormats\OpusFormatTest.cs" />
+    <Compile Include="fixtures\TagLib.Tests.FileFormats\ExtendedTests.cs" />
     <Compile Include="fixtures\TagLib.Tests.FileFormats\StandardTests.cs" />
     <Compile Include="fixtures\TagLib.Tests.Images\AddImageMetadataTests.cs" />
     <Compile Include="fixtures\TagLib.Tests.Images\JpegCanonZoombrowserTest.cs" />


### PR DESCRIPTION
Added support for Replaygain Tags for Ape, Asf and MPEG4 files, including Tests