### PR TITLE
Added the taglib/aiff (.aiff) MIME type

### DIFF
--- a/src/TagLib/Aiff/File.cs
+++ b/src/TagLib/Aiff/File.cs
@@ -33,6 +33,7 @@ namespace TagLib.Aiff
 	///    using the AIFF file format.
 	/// </summary>
 	[SupportedMimeType("taglib/aif", "aif")]
+	[SupportedMimeType("taglib/aiff", "aiff")]
 	[SupportedMimeType("audio/x-aiff")]
 	[SupportedMimeType("audio/aiff")]
 	[SupportedMimeType("sound/aiff")]


### PR DESCRIPTION
.aiff is a common extension for AIFF files, and it was missing from the TagLib.Aiff.File declaration. This PR adds it.

First noticed by https://github.com/mono/taglib/pull/20