### PR TITLE
Wrong bit rate for mp3 vbr

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,4 +31,5 @@ tests/*.xml
 test-results
 .*.swp
 packages
-.vs/taglib-sharp/v14/.suo
+.vs/*
+!packages.config

--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,4 @@ tests/*.xml
 test-results
 .*.swp
 packages
+.vs/taglib-sharp/v14/.suo

--- a/src/TagLib/Mpeg/AudioHeader.cs
+++ b/src/TagLib/Mpeg/AudioHeader.cs
@@ -343,16 +343,16 @@ namespace TagLib.Mpeg {
 		public int AudioBitrate {
 			get {
 				if (xing_header.TotalSize > 0 &&
-					duration > TimeSpan.Zero)
+					Duration > TimeSpan.Zero)
 					return (int) Math.Round (((
 						(XingHeader.TotalSize * 8L) /
-						duration.TotalSeconds) / 1000.0));
+						Duration.TotalSeconds) / 1000.0));
 
 				if (vbri_header.TotalSize > 0 && 
-					duration > TimeSpan.Zero)
+					Duration > TimeSpan.Zero)
 					return (int)Math.Round(((
 						(VBRIHeader.TotalSize * 8L) /
-						duration.TotalSeconds) / 1000.0));
+						Duration.TotalSeconds) / 1000.0));
 				
 				return bitrates [
 					Version == Version.Version1 ? 0 : 1,

--- a/tests/packages.config
+++ b/tests/packages.config
@@ -1,0 +1,4 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="NUnit" version="3.6.1" targetFramework="net45" />
+</packages>


### PR DESCRIPTION
AudioBitrate for MPEG VBR files is calculated wrong, because the private field duration is used in the getter. duration is always zero, if the property Duration was not called before accessing AudioBitrate.