### PR TITLE
Add GtkSharp to packages.config for tests

### DIFF
--- a/README
+++ b/README
@@ -32,7 +32,8 @@ You can also build from MonoDevelop or Visual Studio using taglib-sharp.sln
 To Test/Run from Visual Studio (Windows):
  
  Running regression by using Nunit 3 Test Adapter:
-  1. Download and Install Gtk# for Windows from: http://www.mono-project.com/download/#download-win
+  1. Ensure NuGet packages have been restored
+        See: https://docs.microsoft.com/en-us/nuget/consume-packages/package-restore
   2. In Visual Studio, go to menu: Tools > Extensions and Updates > Online
   3. Search: Nunit 3 Test Adapter
   4. Download and install it

--- a/tests/packages.config
+++ b/tests/packages.config
@@ -1,5 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
+  <package id="GtkSharp" version="3.1.2" targetFramework="net45" />
+  <package id="GtkSharp.Win32" version="3.1.2" targetFramework="net45" />
   <package id="NUnit" version="3.6.1" targetFramework="net45" />
   <package id="NUnit.Console" version="3.6.1" targetFramework="net45" />
   <package id="NUnit.ConsoleRunner" version="3.6.1" targetFramework="net45" />

--- a/tests/tests.csproj
+++ b/tests/tests.csproj
@@ -34,18 +34,21 @@
     <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <ItemGroup>
+    <Reference Include="gdk-sharp, Version=3.0.0.0, Culture=neutral, PublicKeyToken=35e10195dab3c99f, processorArchitecture=MSIL">
+      <HintPath>..\packages\GtkSharp.3.1.2\lib\net45\gdk-sharp.dll</HintPath>
+    </Reference>
+    <Reference Include="gio-sharp, Version=3.0.0.0, Culture=neutral, PublicKeyToken=35e10195dab3c99f, processorArchitecture=MSIL">
+      <HintPath>..\packages\GtkSharp.3.1.2\lib\net45\gio-sharp.dll</HintPath>
+    </Reference>
+    <Reference Include="glib-sharp, Version=3.0.0.0, Culture=neutral, PublicKeyToken=35e10195dab3c99f, processorArchitecture=MSIL">
+      <HintPath>..\packages\GtkSharp.3.1.2\lib\net45\glib-sharp.dll</HintPath>
+    </Reference>
     <Reference Include="nunit.framework, Version=3.6.1.0, Culture=neutral, PublicKeyToken=2638cd05610744eb, processorArchitecture=MSIL">
       <HintPath>..\packages\NUnit.3.6.1\lib\net45\nunit.framework.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System" />
-    <Reference Include="gdk-sharp, Version=2.12.0.0, Culture=neutral, PublicKeyToken=35e10195dab3c99f">
-      <Private>False</Private>
-    </Reference>
     <Reference Include="System.Core" />
-    <Reference Include="glib-sharp, Version=2.12.0.0, Culture=neutral, PublicKeyToken=35e10195dab3c99f">
-      <Private>False</Private>
-    </Reference>
   </ItemGroup>
   <ItemGroup>
     <Compile Include="fixtures\Helpers.cs" />
@@ -190,4 +193,6 @@
   <ItemGroup>
     <Folder Include="Properties\" />
   </ItemGroup>
+  <Import Project="..\packages\GtkSharp.Win32.3.1.2\build\net45\GtkSharp.Win32.targets" Condition="Exists('..\packages\GtkSharp.Win32.3.1.2\build\net45\GtkSharp.Win32.targets')" />
+  <Import Project="..\packages\GtkSharp.3.1.2\build\net45\GtkSharp.targets" Condition="Exists('..\packages\GtkSharp.3.1.2\build\net45\GtkSharp.targets')" />
 </Project>


### PR DESCRIPTION
This PR adds Gtk# as NuGet dependencies so Windows users only have to restore NuGet packages when opening the solution.

According to [tests/Makefile.am](https://github.com/mono/taglib-sharp/blob/master/tests/Makefile.am) this should not break testing on Linux through automake (GNOME_SHARP_LIB references the actual DLLs on Linux), but confirmation would be welcome.