### PR TITLE
Fixing the issue #85 (infinite loop)

### DIFF
--- a/src/TagLib/Riff/File.cs
+++ b/src/TagLib/Riff/File.cs
@@ -621,7 +621,7 @@ namespace TagLib.Riff
 				}
 				
 				// Move to the next item.
-			} while ((position += 8 + size) + 8 < length);
+			} while ((position += 8L + size) + 8 < length);
 			
 			// If we're reading properties, and one were found,
 			// throw an exception. Otherwise, create the Properties


### PR DESCRIPTION
I have added the changes I mentioned in the issue description. In short, for a particular WAV file where the size value is 4294967288, adding 8 overflows the variable and turns it to 0 which makes the loop infinite. 

Simply adding L to 8 explicitly makes it long and the result of 8 + size is also long. The loop stops correctly.