### PR TITLE
fix ArgumentNullException

### DIFF
--- a/src/TagLib/Matroska/Tag.cs
+++ b/src/TagLib/Matroska/Tag.cs
@@ -384,8 +384,7 @@ namespace TagLib.Matroska
 						{
 							str = null;
 						}
-						else
-						if (mtags.Count == 1)
+						else if (mtags.Count == 1)
 						{
 							str = list[0];
 						}

--- a/src/TagLib/Matroska/Tag.cs
+++ b/src/TagLib/Matroska/Tag.cs
@@ -384,6 +384,7 @@ namespace TagLib.Matroska
 						{
 							str = null;
 						}
+						else
 						if (mtags.Count == 1)
 						{
 							str = list[0];


### PR DESCRIPTION
fix `ArgumentNullException `in `string.Join("; ", list)`, when `list == null`