### PR TITLE
Mkv crachfix

### DIFF
--- a/debug/Program.cs
+++ b/debug/Program.cs
@@ -10,7 +10,7 @@ namespace debug
 	{
 		public static readonly string Samples = 
 			Path.GetDirectoryName(System.Reflection.Assembly.GetAssembly(typeof(Program)).Location) 
-			+ @"\..\..\..\tests\samples\";
+			+ @"\..\..\..\..\tests\samples\";
 
 		/// <summary>
 		/// Ouput message on the console and on the Visual Studio Output
@@ -28,6 +28,9 @@ namespace debug
 			log("--------------------");
 			log("* Start : Samples directory: " + Samples);
 			log("");
+
+			// Override command arguments
+//			args = new string[]  { "Unclear Throat (Puisje).mpg" };
 
 			foreach (var fname in args) {
 				var fpath = Samples + fname;

--- a/debug/Program.cs
+++ b/debug/Program.cs
@@ -30,7 +30,7 @@ namespace debug
 			log("");
 
 			// Override command arguments
-//			args = new string[]  { "Unclear Throat (Puisje).mpg" };
+			args = new string[]  { "Turning Lime.mkv" };
 
 			foreach (var fname in args) {
 				var fpath = Samples + fname;

--- a/debug/debug.csproj
+++ b/debug/debug.csproj
@@ -2,6 +2,9 @@
 
   <PropertyGroup>
     <TargetFrameworks>net40;netstandard2.0</TargetFrameworks>
+    <ApplicationIcon />
+    <OutputType>Exe</OutputType>
+    <StartupObject />
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/TagLib/Matroska/Tags.cs
+++ b/src/TagLib/Matroska/Tags.cs
@@ -130,8 +130,8 @@ namespace TagLib.Matroska
 
 			base.ClearItems();
 
-			// Keep Medium Tag reference unchanged
-			Add(medium);
+			// Keep Medium Tag reference unchanged (if any)
+			if (medium != null) Add(medium);
 		}
 
 


### PR DESCRIPTION
This contains an improved handling of corrupted (truncated) Matroska files.
When a incomplete Matroska file is read by TagLib#, the following behavior is changed:
- Returns a Corrupted file instead of issuing an exception
- Best effort done to retrieve data at the begining of the file (like properties)
- As a result, a `TagLib.File.Create` will most of the time return something, but the returned object may be marked as corrupted.