### PR TITLE
Nunit update

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,4 +22,3 @@ script:
   - msbuild taglib-sharp.sln
   - cd tests
   - mono ../packages/NUnit.ConsoleRunner.3.8.0/tools/nunit3-console.exe --labels=All tests.dll
- 

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,3 +22,4 @@ script:
   - msbuild taglib-sharp.sln
   - cd tests
   - mono ../packages/NUnit.ConsoleRunner.3.8.0/tools/nunit3-console.exe --labels=All tests.dll
+ 

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,11 +14,11 @@ before_install:
 install:
   - sudo apt-get update -qq > /dev/null
   - mono .nuget/nuget.exe restore taglib-sharp.sln -Verbosity detailed
-  - mono .nuget/nuget.exe install NUnit.Runners -Version 3.2.1 -OutputDirectory packages
+  - mono .nuget/nuget.exe install NUnit.Runners -Version 3.8.0 -OutputDirectory packages
   - dotnet restore
 
 script:
   - ./autogen.sh
   - msbuild taglib-sharp.sln
   - cd tests
-  - mono ../packages/NUnit.ConsoleRunner.3.6.1/tools/nunit3-console.exe --labels=All tests.dll
+  - mono ../packages/NUnit.ConsoleRunner.3.8.0/tools/nunit3-console.exe --labels=All tests.dll

--- a/tests/MainWindow.cs
+++ b/tests/MainWindow.cs
@@ -1,0 +1,38 @@
+﻿using Gtk;
+
+public class MainWindow : Window
+{
+        static void Main(string[] args)
+        {
+                Application.Init ();
+
+                new MainWindow ();
+
+                Application.Run();
+        }
+
+        public MainWindow() : base("MainWindow")
+        {
+                // Setup ui
+                var textview = new TextView();
+                Add (textview);
+
+                // Setup tag
+                var tag = new TextTag ("helloworld-tag");
+                tag.Scale = Pango.Scale.XXLarge;
+                tag.Style = Pango.Style.Italic;
+                tag.Underline = Pango.Underline.Double;
+                tag.Foreground = "blue";
+                tag.Background = "pink";
+                tag.Justification = Justification.Center;
+                var buffer = textview.Buffer;
+                buffer.TagTable.Add (tag);
+
+                // Insert "Hello world!" into textview buffer
+                var insertIter = buffer.StartIter;
+                buffer.InsertWithTagsByName (ref insertIter, "Hello World!\n", "helloworld-tag");
+                buffer.Insert (ref insertIter, "Simple Hello World!");
+
+                ShowAll ();
+        }
+}

--- a/tests/packages.config
+++ b/tests/packages.config
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="GtkSharp" version="3.1.2" targetFramework="net45" />
   <package id="GtkSharp.Win32" version="3.1.2" targetFramework="net45" />
@@ -10,6 +10,5 @@
   <package id="NUnit.Extension.NUnitV2ResultWriter" version="3.6.0" targetFramework="net45" />
   <package id="NUnit.Extension.TeamCityEventListener" version="1.0.3" targetFramework="net45" />
   <package id="NUnit.Extension.VSProjectLoader" version="3.7.0" targetFramework="net45" />
-  <package id="NUnit3TestAdapter" version="3.10.0" targetFramework="net45" />
   <package id="NUnit3TestAdapter" version="3.10.0" targetFramework="net45" />
 </packages>

--- a/tests/packages.config
+++ b/tests/packages.config
@@ -10,4 +10,5 @@
   <package id="NUnit.Extension.NUnitV2ResultWriter" version="3.5.0" targetFramework="net45" />
   <package id="NUnit.Extension.TeamCityEventListener" version="1.0.2" targetFramework="net45" />
   <package id="NUnit.Extension.VSProjectLoader" version="3.5.0" targetFramework="net45" />
+  <package id="NUnit3TestAdapter" version="3.10.0" targetFramework="net45" />
 </packages>

--- a/tests/tests.csproj
+++ b/tests/tests.csproj
@@ -1,5 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003" ToolsVersion="4.0">
+  <Import Project="..\packages\NUnit3TestAdapter.3.10.0\build\net35\NUnit3TestAdapter.props" Condition="Exists('..\packages\NUnit3TestAdapter.3.10.0\build\net35\NUnit3TestAdapter.props')" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
@@ -14,6 +15,8 @@
     <AssemblyOriginatorKeyFile>..\taglib-sharp.snk</AssemblyOriginatorKeyFile>
     <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
     <TargetFrameworkProfile />
+    <NuGetPackageImportStamp>
+    </NuGetPackageImportStamp>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>True</DebugSymbols>
@@ -197,4 +200,10 @@
   </ItemGroup>
   <Import Project="..\packages\GtkSharp.Win32.3.1.2\build\net45\GtkSharp.Win32.targets" Condition="Exists('..\packages\GtkSharp.Win32.3.1.2\build\net45\GtkSharp.Win32.targets')" />
   <Import Project="..\packages\GtkSharp.3.1.2\build\net45\GtkSharp.targets" Condition="Exists('..\packages\GtkSharp.3.1.2\build\net45\GtkSharp.targets')" />
+  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
+    <PropertyGroup>
+      <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
+    </PropertyGroup>
+    <Error Condition="!Exists('..\packages\NUnit3TestAdapter.3.10.0\build\net35\NUnit3TestAdapter.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\NUnit3TestAdapter.3.10.0\build\net35\NUnit3TestAdapter.props'))" />
+  </Target>
 </Project>


### PR DESCRIPTION
This updates the Nunit package to NUnit v3.10.1, and restore the Visual Studio Nunit 3 Test Adapter nugget. This re-enables the Nunit tests to be run in Visual Studio, as this has been broken in the transition to .Net framework 2.0.