### PR TITLE
Added fix for chunks with odd-sized lengths

### DIFF
--- a/src/TagLib/Riff/File.cs
+++ b/src/TagLib/Riff/File.cs
@@ -478,11 +478,16 @@ namespace TagLib.Riff
 			// Read until there are less than 8 bytes to read.
 			do {
 				bool tag_found = false;
-				
+
+				// Check if the current position is an odd number and increment it so it is even
+				// This is done when the previous chunk size was an odd number.
+				// If this is not done, the chunk being read after the odd chunk will not be read.
+				if (position > 12 && (position & 1) != 0) { position++; }
+
 				Seek (position);
 				string fourcc = ReadBlock (4).ToString (StringType.UTF8);
 				size = ReadBlock (4).ToUInt (false);
-				
+
 				switch (fourcc)
 				{
 				


### PR DESCRIPTION
This addresses #101.

TagLib# does not handle reading a chunk when the position value is odd.  Having a chunk with an odd size before the data chunk forces TagLib# to never read the data chunk. Therefore the duration is never calculated as well as some other members are not populated.

This PR fixes this by checking if the chunk is odd and increments the position by one byte.