### PR TITLE
Misc fixes and front-page documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,9 @@
 
 
 (aka *Taglib-sharp*) is a library for reading and writing
-metadata in media files, including video, audio, and photo formats.
+metadata in media files, including video, audio, and photo formats. 
+This is a convenient one-stop-shop to present or tag all your media collection, regardless of which format/container 
+these might use.
 
 It supports the following formats (by file-extensions):
  * **Video:** mkv, ogv, avi, wmv, asf, mp4 (m4p, m4v), mpeg (mpg, mpe, mpv, mpg, m2v)

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 [![Windows Build status](https://ci.appveyor.com/api/projects/status/v7vwgphs239i14ya?svg=true)](https://ci.appveyor.com/project/decriptor/taglib-sharp)
 
 
-(aka *Taglib-sharp*) is a platform independent library (tested on Windows/Linux), built on .NET, for reading and writing
+(aka *Taglib-sharp*) is a .NET platform-independent library (tested on Windows/Linux) for reading and writing
 metadata in media files, including video, audio, and photo formats. 
 This is a convenient one-stop-shop to present or tag all your media collection, regardless of which format/container 
 these might use. You can read/write the standard or more common tags/properties of a media, or you can also create and
@@ -14,7 +14,7 @@ retrieve your own custom tags.
 
 It supports the following formats (by file-extensions):
  * **Video:** mkv, ogv, avi, wmv, asf, mp4 (m4p, m4v), mpeg (mpg, mpe, mpv, mpg, m2v)
- * **Audio:** aa, aax, aac, aiff, ape, flac, m4a, m4b, m4p, mp3, mpc, mpp, ogg, oga, wav, wma, wv, webm
+ * **Audio:** aa, aax, aac, aiff, ape, dsf, flac, m4a, m4b, m4p, mp3, mpc, mpp, ogg, oga, wav, wma, wv, webm
  * **Images:** bmp, gif, jpeg, pbm, pgm, ppm, pnm, pcx, png, tiff, dng, svg
 
 It is API stable, with only API additions (not changes or removals)

--- a/README.md
+++ b/README.md
@@ -12,19 +12,17 @@ metadata in media files, including video, audio, and photo formats.
 It is API stable, with only API additions (not changes or removals)
 occuring in the 2.0 series.
 
- * Bugs:     <https://bugzilla.gnome.org/page.cgi?id=browse.html&product=taglib-sharp>
- * Tarballs: <http://banshee.fm/download/>
- * IRC:      Several TagLib# developers are often in #banshee on irc.gnome.org
- * Git:      <https://github.com/mono/taglib-sharp> or <git://github.com/mono/taglib-sharp.git>
-
-TagLib# is free/open source software, released under the LGPL.
-We welcome contributions!  Please try to match our coding style,
-and include unit tests with any patches.  Patches can be submitted
-by filing a bug and attaching the diff to it.
+## Website
+TagLib# is available on GitHub: <https://github.com/mono/taglib-sharp>
+ * Bugs:     Create an issue in <https://github.com/mono/taglib-sharp/issues>
+ * Chat:     Join us at Gitter <https://gitter.im/mono/taglib-sharp>
+ * Git:      Get the source at <git://github.com/mono/taglib-sharp.git>
 
 ## Building and Running
 
-### To Build From Git:
+### Command Line  (Linux)
+
+#### To Build From Git:
 
 ```sh
 git clone https://github.com/mono/taglib-sharp.git
@@ -32,23 +30,27 @@ cd taglib-sharp
 ./autogen.sh && make
 ```
 
-### To Build From Tarball:
+#### To Build From Tarball:
 
 ```
 ./configure && make
 ```
 
-### To Test:
+#### To Test:
 
 ```
 make test
 ```
 
-You can also build from MonoDevelop or Visual Studio using taglib-sharp.sln
+### MonoDevelop  (Linux)
 
-### To Test/Run from Visual Studio (Windows):
+You can build from MonoDevelop using taglib-sharp.sln
 
-Running regression by using Nunit 3 Test Adapter:
+### Visual Studio (Windows):
+
+You can open it in Visual Studio by using taglib-sharp.sln
+
+#### Running regression by using Nunit 3 Test Adapter:
  
 1. Ensure NuGet packages have been restored
     1. See: <https://docs.microsoft.com/en-us/nuget/consume-packages/package-restore>
@@ -61,9 +63,17 @@ Running regression by using Nunit 3 Test Adapter:
    1. Double click on a test. Set some breakpoints in the test in the editor panel.
    2. right-click on the same test, select "Debug Selected tests".
 
-To test some scenarios and take advantage of the debugger:
+#### To test some scenarios and take advantage of the debugger:
 
 1. Make the "debug" project the Startup project
     (Right-click on the project, select: "Set as StartUp Project")
 2. Just modify the "Program.cs"
 3. Set some breakpoints and hit the "Start" button
+
+## Contributions
+
+TagLib# is free/open source software, released under the LGPL.
+We welcome contributions!  Please try to match our coding style,
+and include unit tests with any patches.  Patches can be submitted
+by issuing a Pull Request (Git).
+

--- a/README.md
+++ b/README.md
@@ -6,17 +6,22 @@
 [![Windows Build status](https://ci.appveyor.com/api/projects/status/v7vwgphs239i14ya?svg=true)](https://ci.appveyor.com/project/decriptor/taglib-sharp)
 
 
-(aka taglib-sharp) is a library for reading and writing
+(aka *Taglib-sharp*) is a library for reading and writing
 metadata in media files, including video, audio, and photo formats.
+
+It supports the following formats (by file extensions):
+ * **Video:** mkv, ogv, avi, wmv, asf, mp4 (m4p, m4v), mpeg (mpg, mpe, mpv, mpg, m2v)
+	* **Audio:** aa, aax, aac, aiff, ape, flac, m4a, m4b, m4p, mp3, mpc, mpp, ogg, oga, opus, sln, wav, wma, wv, webm
+	* **Images:** bmp, gif, jpeg, pbm, pgm, ppm, pnm, pcx, png, tiff, dng, svg
 
 It is API stable, with only API additions (not changes or removals)
 occuring in the 2.0 series.
 
 ## Website
 TagLib# is available on GitHub: <https://github.com/mono/taglib-sharp>
- * Bugs:     Create an issue in <https://github.com/mono/taglib-sharp/issues>
- * Chat:     Join us at Gitter <https://gitter.im/mono/taglib-sharp>
- * Git:      Get the source at <git://github.com/mono/taglib-sharp.git>
+ * **Bugs:**     Create an issue in <https://github.com/mono/taglib-sharp/issues>
+ * **Chat:**     Join us at Gitter <https://gitter.im/mono/taglib-sharp>
+ * **Git:**      Get the source at <git://github.com/mono/taglib-sharp.git>
 
 ## Building and Running
 

--- a/README.md
+++ b/README.md
@@ -9,21 +9,79 @@
 (aka *Taglib-sharp*) is a library for reading and writing
 metadata in media files, including video, audio, and photo formats. 
 This is a convenient one-stop-shop to present or tag all your media collection, regardless of which format/container 
-these might use.
+these might use. You can read/write the standard or more common tags/properties of a media, or you can also create and
+retrieve your own custom tags.
 
 It supports the following formats (by file-extensions):
  * **Video:** mkv, ogv, avi, wmv, asf, mp4 (m4p, m4v), mpeg (mpg, mpe, mpv, mpg, m2v)
- * **Audio:** aa, aax, aac, aiff, ape, flac, m4a, m4b, m4p, mp3, mpc, mpp, ogg, oga, opus, sln, wav, wma, wv, webm
+ * **Audio:** aa, aax, aac, aiff, ape, flac, m4a, m4b, m4p, mp3, mpc, mpp, ogg, oga, wav, wma, wv, webm
  * **Images:** bmp, gif, jpeg, pbm, pgm, ppm, pnm, pcx, png, tiff, dng, svg
 
 It is API stable, with only API additions (not changes or removals)
 occuring in the 2.0 series.
 
+
+## Examples
+
+### Read/write metadata from a video
+```C#
+var tfile = TagLib.File.Create(@"C:\My video.avi");
+string title = tfile.Tag.Title;
+TimeSpan duration = tfile.Properties.Duration;
+Console.WriteLine("Title: {0}, duration: {1}", title, duration);
+
+// change title in the file
+tfile.Tag.Title = "my new title";
+tfile.Save();
+```
+
+### Read/write metadata from a Audio file
+```C#
+var tfile = TagLib.File.Create(@"C:\My audio.mp3");
+string title = tfile.Tag.Title;
+TimeSpan duration = tfile.Properties.Duration;
+Console.WriteLine("Title: {0}, duration: {1}", title, duration);
+
+// change title in the file
+tfile.Tag.Title = "my new title";
+tfile.Save();
+```
+
+### Read/write metadata from an Image
+```C#
+var tfile = TagLib.File.Create(@"C:\My picture.jpg");
+string title = tfile.Tag.Title;
+var tag =  tfile.Tag as TagLib.Image.CombinedImageTag;
+DateTime? snapshot = tag.DateTime;
+Console.WriteLine("Title: {0}, snapshot taken on {1}", title, snapshot);
+
+// change title in the file
+tfile.Tag.Title = "my new title";
+tfile.Save();
+```
+
+### Read/write custom tags from a specific format
+```C#
+var tfile = TagLib.File.Create(@"C:\My song.flac");
+var custom = (TagLib.Ogg.XiphComment) tfile.GetTag(TagLib.TagTypes.Xiph);
+
+// Read
+string [] myfields = custom.GetField("MY_TAG");
+Console.WriteLine("First MY_TAG entry: {0}", myfields[0]);
+
+// Write
+custom.SetField("MY_TAG", new string[] { "value1", "value2" });
+custom.RemoveField("OTHER_FIELD");
+rgFile.Save();
+```
+
+
 ## Website
 TagLib# is available on GitHub: <https://github.com/mono/taglib-sharp>
- * **Bugs:**     Create an issue in <https://github.com/mono/taglib-sharp/issues>
- * **Chat:**     Join us at Gitter <https://gitter.im/mono/taglib-sharp>
- * **Git:**      Get the source at <git://github.com/mono/taglib-sharp.git>
+* **Bugs:**     Create an [issue](https://github.com/mono/taglib-sharp/issues)
+* **Chat:**     Join us at [Gitter](https://gitter.im/mono/taglib-sharp)
+* **Git:**      Get the source at <git://github.com/mono/taglib-sharp.git>
+
 
 ## Building and Running
 
@@ -76,6 +134,16 @@ You can open it in Visual Studio by using taglib-sharp.sln
     (Right-click on the project, select: "Set as StartUp Project")
 2. Just modify the "Program.cs"
 3. Set some breakpoints and hit the "Start" button
+
+
+
+## They also use TagLib#
+Non exhaustive list of projects that use TagLib#:
+* [Lidarr](https://lidarr.audio/)
+* [MediaPortal 2](https://www.team-mediaportal.com/wiki/display/MediaPortal2/MediaPortal+2)
+* [F-Spot](https://en.wikipedia.org/wiki/F-Spot)
+
+And you, what do you use TagLib# for ? Reply [here](https://github.com/mono/taglib-sharp/issues/120)
 
 ## Contributions
 

--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ cd taglib-sharp
 make test
 ```
 
-### MonoDevelop  (Linux)
+### Mono Develop  (Linux)
 
 You can build from MonoDevelop using taglib-sharp.sln
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 [![Windows Build status](https://ci.appveyor.com/api/projects/status/v7vwgphs239i14ya?svg=true)](https://ci.appveyor.com/project/decriptor/taglib-sharp)
 
 
-(aka *Taglib-sharp*) is a library for reading and writing
+(aka *Taglib-sharp*) is a platform independent library (tested on Windows/Linux), built on .NET, for reading and writing
 metadata in media files, including video, audio, and photo formats. 
 This is a convenient one-stop-shop to present or tag all your media collection, regardless of which format/container 
 these might use. You can read/write the standard or more common tags/properties of a media, or you can also create and

--- a/README.md
+++ b/README.md
@@ -9,10 +9,10 @@
 (aka *Taglib-sharp*) is a library for reading and writing
 metadata in media files, including video, audio, and photo formats.
 
-It supports the following formats (by file extensions):
+It supports the following formats (by file-extensions):
  * **Video:** mkv, ogv, avi, wmv, asf, mp4 (m4p, m4v), mpeg (mpg, mpe, mpv, mpg, m2v)
-	* **Audio:** aa, aax, aac, aiff, ape, flac, m4a, m4b, m4p, mp3, mpc, mpp, ogg, oga, opus, sln, wav, wma, wv, webm
-	* **Images:** bmp, gif, jpeg, pbm, pgm, ppm, pnm, pcx, png, tiff, dng, svg
+ * **Audio:** aa, aax, aac, aiff, ape, flac, m4a, m4b, m4p, mp3, mpc, mpp, ogg, oga, opus, sln, wav, wma, wv, webm
+ * **Images:** bmp, gif, jpeg, pbm, pgm, ppm, pnm, pcx, png, tiff, dng, svg
 
 It is API stable, with only API additions (not changes or removals)
 occuring in the 2.0 series.

--- a/src/TagLib/Id3v2/Frames/AttachmentFrame.cs
+++ b/src/TagLib/Id3v2/Frames/AttachmentFrame.cs
@@ -739,7 +739,7 @@ namespace TagLib.Id3v2 {
 			finally
 			{
 				// Free the resources
-				if (stream != null)
+				if (stream != null && file != null)
 				{
 					file.CloseStream(stream);
 				}

--- a/src/TagLib/Mpeg/AudioHeader.cs
+++ b/src/TagLib/Mpeg/AudioHeader.cs
@@ -473,14 +473,15 @@ namespace TagLib.Mpeg {
 					// Since there was no valid Xing or VBRI
 					// header found, we hope that we're in a
 					// constant bitrate file.
-					
-					int frames = (int) (stream_length
-						 / AudioFrameLength + 1);
+
+					// Round off to upper integer value
+					int frames = (int) ((stream_length + 
+						AudioFrameLength - 1) /
+						AudioFrameLength);
 					
 					duration = TimeSpan.FromSeconds (
 						(double) (AudioFrameLength *
-						frames) / (double)
-						(AudioBitrate * 125) + 0.5);
+						frames) / (AudioBitrate * 125));
 				}
 				
 				return duration;

--- a/src/TagLib/PictureLazy.cs
+++ b/src/TagLib/PictureLazy.cs
@@ -269,7 +269,7 @@ namespace TagLib {
 			finally
 			{
 				// Free the resources
-				if (stream != null)
+				if (stream != null && file != null)
 				{
 					file.CloseStream(stream);
 				}

--- a/src/TagLib/Riff/AviHeaderList.cs
+++ b/src/TagLib/Riff/AviHeaderList.cs
@@ -104,8 +104,7 @@ namespace TagLib.Riff
 			{
 				if (list_data.StartsWith("strl"))
 				{
-					AviStream stream = AviStream
-						.ParseStreamList(list_data);
+					AviStream stream = AviStream.ParseStreamList(list_data);
 					if (stream != null)
 						codecs.Add(stream.Codec);
 				}

--- a/src/TagLib/Riff/AviHeaderList.cs
+++ b/src/TagLib/Riff/AviHeaderList.cs
@@ -99,12 +99,17 @@ namespace TagLib.Riff
 					"Invalid header length.");
 			
 			header = new AviHeader (header_data, 0);
-			
-			foreach (ByteVector list_data in list ["LIST"])
-				if (list_data.StartsWith ("strl"))
-					codecs.Add (AviStream
-						.ParseStreamList (list_data)
-						.Codec);
+
+			foreach (ByteVector list_data in list["LIST"])
+			{
+				if (list_data.StartsWith("strl"))
+				{
+					AviStream stream = AviStream
+						.ParseStreamList(list_data);
+					if (stream != null)
+						codecs.Add(stream.Codec);
+				}
+			}
 		}
 		
 		/// <summary>


### PR DESCRIPTION
After enabling my project to run TagLib# more extensively on on my video collection, I spotted a few new corner-cases where we could trigger a null-reference exception. Also integrated issues #116 and #119.

- Updated GitHub front-page for TagLib# as discussed in #116
  You can see how it looks like at: https://github.com/Starwer/taglib-sharp/tree/miscfix_doc
- Fixed wrong duration issue as reported in #119;
- Fixed null reference exceptions in different spots; 