### PR TITLE
Fixed: Mpeg4 Box Header Exception Format

### DIFF
--- a/src/TagLib/Mpeg4/BoxHeader.cs
+++ b/src/TagLib/Mpeg4/BoxHeader.cs
@@ -151,7 +151,7 @@ namespace TagLib.Mpeg4 {
 				extended_type = null;
 
 			if (box_size > (ulong) (file.Length - position)) {
-				throw new CorruptFileException ("Box header specified a size of {0} bytes but only {1} bytes left in the file");
+				throw new CorruptFileException (string.Format("Box header specified a size of {0} bytes but only {1} bytes left in the file", box_size, file.Length - position));
 			}
 		}
 		


### PR DESCRIPTION
Fixes the Box header exception format to pass parameters correctly instead of `{0}` and `{1}`