### PR TITLE
[Matroska] Handle CRC-32 element in SeekHead instead of marking it Corrupt

### DIFF
--- a/src/TagLib/Matroska/File.cs
+++ b/src/TagLib/Matroska/File.cs
@@ -744,6 +744,12 @@ namespace TagLib.Matroska
 				EBMLreader ebml_seek = new EBMLreader(element, element.DataOffset + i);
 				MatroskaID matroska_id = ebml_seek.ID;
 
+				if (matroska_id == MatroskaID.CRC32) // Skip the CRC-32 element
+				{
+					i += ebml_seek.Size;
+					continue;
+				}
+
 				if (matroska_id != MatroskaID.Seek) return false; // corrupted SeekHead
 
 				ulong j = 0;


### PR DESCRIPTION
According to the specifications Top Level elements should include a CRC-32 element as a child segment. (http://matroska-org.github.io/matroska-specification/ordering.html)
A SeekHead is a top level element (https://matroska.org/technical/specs/index.html)
This patch handles a CRC-32 element if found in a SeekHead, don't return false otherwise the SeekHead is marked a corrupted and metadata is never written to the file while saving.

@Starwer can you please review this