### PR TITLE
Fix flag and version bytes where not being correctly written

### DIFF
--- a/src/TaglibSharp/Mpeg4/AppleTag.cs
+++ b/src/TaglibSharp/Mpeg4/AppleTag.cs
@@ -435,8 +435,8 @@ namespace TagLib.Mpeg4
 				data_box.Text = datastring;
 			} else {
 				//Create the new boxes, should use 1 for text as a flag
-				var amean_box = new AppleAdditionalInfoBox (BoxType.Mean);
-				var aname_box = new AppleAdditionalInfoBox (BoxType.Name);
+				var amean_box = new AppleAdditionalInfoBox (BoxType.Mean,0,1);
+				var aname_box = new AppleAdditionalInfoBox (BoxType.Name,0,1);
 				var adata_box = new AppleDataBox (BoxType.Data, 1);
 				amean_box.Text = meanstring;
 				aname_box.Text = namestring;

--- a/src/TaglibSharp/Mpeg4/Boxes/AppleAdditionalInfoBox.cs
+++ b/src/TaglibSharp/Mpeg4/Boxes/AppleAdditionalInfoBox.cs
@@ -30,7 +30,7 @@ namespace TagLib.Mpeg4
 	///    This class extends <see cref="Box" /> to provide an
 	///    implementation of an Apple AdditionalInfoBox.
 	/// </summary>
-	public class AppleAdditionalInfoBox : Box
+	public class AppleAdditionalInfoBox : FullBox
 	{
 		#region Private Fields
 
@@ -66,11 +66,11 @@ namespace TagLib.Mpeg4
 		///    <paramref name="file" /> is <see langword="null" />.
 		/// </exception>
 		public AppleAdditionalInfoBox (BoxHeader header, TagLib.File file, IsoHandlerBox handler)
-			: base (header, handler)
+			: base (header, file, handler)
 		{
 			// We do not care what is in this custom data section
 			// see: https://developer.apple.com/library/mac/#documentation/QuickTime/QTFF/QTFFChap2/qtff2.html
-			Data = LoadData (file);
+			Data = file.ReadBlock(DataSize > 0 ? DataSize : 0);
 		}
 
 		/// <summary>
@@ -78,7 +78,7 @@ namespace TagLib.Mpeg4
 		///    cref="AppleAdditionalInfoBox" /> using specified header, version and flags
 		/// </summary>
 		/// <param name="header">defines the header data</param>
-		public AppleAdditionalInfoBox (ByteVector header) : base (header)
+		public AppleAdditionalInfoBox (ByteVector header, byte version, uint flags) : base (header, version, flags)
 		{
 		}
 


### PR DESCRIPTION
Ported pull request #18 and baselined with the latest code base

This has been tested and is working fine with Dash Atoms as expected. Verified with Atomic Parsley.

NOTE: GitHub is automatically normalizing the CR-LF's for AppleTag.cs so it shows a huge diff, can't find a way to disable it.