### PR TITLE
re-add pkg-config support

### DIFF
--- a/taglib-sharp.pc.in
+++ b/taglib-sharp.pc.in
@@ -1,0 +1,8 @@
+prefix=@prefix@
+exec_prefix=${prefix}
+libdir=${exec_prefix}/lib
+
+Name: TagLib Sharp
+Description: A .NET platform-independent library for reading and writing metadata in media files, including video, audio, and photo formats.
+Version: 2.2.0.0
+Libs: -r:${libdir}/mono/taglib-sharp/TagLibSharp.dll


### PR DESCRIPTION
This brings back pkg-config support by re-adding the .pc.in file. Users can change the prefix and version parameters accordingly via `sed`. Fixes #171.