### PR TITLE
Fixes #200 and copies Pictures over from Id3v2 Tag to File.Tag

### DIFF
--- a/src/TaglibSharp/Tag.cs
+++ b/src/TaglibSharp/Tag.cs
@@ -1563,6 +1563,9 @@ namespace TagLib
 
 			if (overwrite || target.DateTagged == null)
 				target.DateTagged = DateTagged;
+
+			if (overwrite || target.Pictures.Length == 0)
+				target.Pictures = Pictures;
 		}
 
 		/// <summary>

--- a/src/TaglibSharp/Tag.cs
+++ b/src/TaglibSharp/Tag.cs
@@ -1564,7 +1564,7 @@ namespace TagLib
 			if (overwrite || target.DateTagged == null)
 				target.DateTagged = DateTagged;
 
-			if (overwrite || target.Pictures.Length == 0)
+			if (overwrite || target.Pictures == null || target.Pictures.Length == 0)
 				target.Pictures = Pictures;
 		}
 


### PR DESCRIPTION
Ensures that `Pictures` on the `Id3v2` object are copied over to the `File.Tag` on a `CopyTo` operation.