### PR TITLE
Add support for webm audio files

### DIFF
--- a/src/TaglibSharp/Matroska/File.cs
+++ b/src/TaglibSharp/Matroska/File.cs
@@ -69,6 +69,7 @@ namespace TagLib.Matroska
 	[SupportedMimeType ("taglib/mkv", "mkv")]
 	[SupportedMimeType ("taglib/mka", "mka")]
 	[SupportedMimeType ("taglib/mks", "mks")]
+	[SupportedMimeType ("taglib/webm", "webm")]
 	[SupportedMimeType ("video/webm")]
 	[SupportedMimeType ("video/x-matroska")]
 	public class File : TagLib.File


### PR DESCRIPTION
The readme says that webm audio files are supported, however trying to load them produces a FileNotSupported exception. i.e. open audio.webm

Adding taglib/webm allows the file to be opened and tags be written to the file.  