### PR TITLE
Fixed KeyNotFoundException in IFDReader

### DIFF
--- a/src/TaglibSharp/IFD/IFDReader.cs
+++ b/src/TaglibSharp/IFD/IFDReader.cs
@@ -238,8 +238,8 @@ namespace TagLib.IFD
 			}
 		}
 
-		static readonly Dictionary<File, List<long>> ifd_offsets = new Dictionary<File, List<long>> ();
-		static readonly Dictionary<File, int> ifd_loopdetect_refs = new Dictionary<File, int> ();
+		readonly Dictionary<File, List<long>> ifd_offsets = new Dictionary<File, List<long>> ();
+		readonly Dictionary<File, int> ifd_loopdetect_refs = new Dictionary<File, int> ();
 
 		/// <summary>
 		///    Reads an IFD from file at position <paramref name="offset"/> relative


### PR DESCRIPTION
Hi!
By testing the taglib-sharp by multi-thread processing the bunch of jpgs I've encountered the  unhandled KeyNotFoundException. I've found and fixed the bug and tested the lib again. 
It works correctly on my side now.
Would you like to merge my small bugfix into the master?  