### PR TITLE
Added support for chapters by implementing the frames CHAP and CTOC

### DIFF
--- a/src/TaglibSharp/ByteVector.cs
+++ b/src/TaglibSharp/ByteVector.cs
@@ -1495,7 +1495,7 @@ namespace TagLib
 		/// </returns>
 		public override string ToString ()
 		{
-			return ToString (StringType.UTF8);
+			return ToString (StringType.UTF8, 0, Count);
 		}
 
 		/// <summary>

--- a/src/TaglibSharp/Id3v2/FrameFactory.cs
+++ b/src/TaglibSharp/Id3v2/FrameFactory.cs
@@ -139,7 +139,7 @@ namespace TagLib.Id3v2
 				position = offset;
 			}
 
-			// If the next data is position is 0, assume
+			// If the next data in position is 0, assume
 			// that we've hit the padding portion of the
 			// frame data.
 
@@ -162,8 +162,8 @@ namespace TagLib.Id3v2
 			}
 
 			if (alreadyUnsynched) {
-				// Mark the frame as not Unsynchronozed because the entire
-				// tag has already been Unsynchronized
+				// Mark the frame as not unsynchronized because the entire
+				// tag has already been unsynchronized
 				header.Flags &= ~FrameFlags.Unsynchronisation;
 			}
 
@@ -270,6 +270,10 @@ namespace TagLib.Id3v2
 			if (header.FrameId == FrameType.PRIV)
 				return new PrivateFrame (data, position, header, version);
 
+			// User Url Link (frames 4.3.2)
+			if (header.FrameId == FrameType.WXXX)
+				return new UserUrlLinkFrame (data, position, header, version);
+
 			// Url Link (frames 4.3.1)
 			if (header.FrameId[0] == (byte)'W')
 				return new UrlLinkFrame (data, position, header, version);
@@ -277,6 +281,14 @@ namespace TagLib.Id3v2
 			// Event timing codes (frames 4.6)
 			if (header.FrameId == FrameType.ETCO)
 				return new EventTimeCodesFrame (data, position, header, version);
+
+			// Chapter (ID3v2 Chapter Frame Addendum)
+			if (header.FrameId == FrameType.CHAP)
+				return new ChapterFrame (data, position, header, version);
+
+			// Table of Contents (ID3v2 Chapter Frame Addendum)
+			if (header.FrameId == FrameType.CTOC)
+				return new TableOfContentsFrame (data, position, header, version);
 
 			return new UnknownFrame (data, position, header, version);
 		}

--- a/src/TaglibSharp/Id3v2/FrameTypes.cs
+++ b/src/TaglibSharp/Id3v2/FrameTypes.cs
@@ -40,6 +40,8 @@ namespace TagLib.Id3v2
 	{
 		public static readonly ReadOnlyByteVector APIC = "APIC";
 		public static readonly ReadOnlyByteVector COMM = "COMM";
+		public static readonly ReadOnlyByteVector CHAP = "CHAP"; // Chapter Frame
+		public static readonly ReadOnlyByteVector CTOC = "CTOC"; // Table of Contents Frame
 		public static readonly ReadOnlyByteVector EQUA = "EQUA";
 		public static readonly ReadOnlyByteVector GEOB = "GEOB";
 		public static readonly ReadOnlyByteVector IPLS = "IPLS";

--- a/src/TaglibSharp/Id3v2/Frames/ChapterFrame.cs
+++ b/src/TaglibSharp/Id3v2/Frames/ChapterFrame.cs
@@ -248,5 +248,31 @@ namespace TagLib.Id3v2
 		}
 
 		#endregion
+
+
+		#region ICloneable
+
+		/// <summary>
+		///    Creates a deep copy of the current instance.
+		/// </summary>
+		/// <returns>
+		///    A new <see cref="Frame" /> object identical to the
+		///    current instance.
+		/// </returns>
+		public override Frame Clone()
+		{
+			var frame = new ChapterFrame(Id);
+			frame.StartMilliseconds = StartMilliseconds;
+			frame.EndMilliseconds = EndMilliseconds;
+			frame.StartByteOffset = StartByteOffset;
+			frame.EndByteOffset = EndByteOffset;
+
+			foreach(var f in SubFrames)
+				frame.SubFrames.Add(f.Clone());
+
+			return frame;
+		}
+
+		#endregion
 	}
 }

--- a/src/TaglibSharp/Id3v2/Frames/ChapterFrame.cs
+++ b/src/TaglibSharp/Id3v2/Frames/ChapterFrame.cs
@@ -1,0 +1,252 @@
+using System;
+using System.Collections.Generic;
+
+namespace TagLib.Id3v2
+{
+	/// <summary>
+	///    This class extends <see cref="Frame" /> to provide support for
+	///    Chapter Frames, i.e. "<c>CHAP</c>", (ID3v2 Chapter Frame Addendum 1.0,
+	///    https://id3.org/id3v2-chapters-1.0).
+	/// </summary>
+	/// <remarks>
+	///    The Chapter Frame is special in that it can hold an arbitrary amount
+	///    of sub-frames, which are made available here in the SubFrames list.
+	///
+	///    Each Chapter Frame must have an identifying string that is unique across
+	///    all <see cref="ChapterFrame"/>s and <see cref="TableOfContentsFrame"/>s
+	///    in the tag. This is the property <see cref="Id"/>. It is not intended
+	///    for humans consumption and players will not display it. A chapter can
+	///    be titled by adding a "<c>TIT2</c>" <see cref="TextInformationFrame"/>.
+	///
+	///    There are two ways the Chapter Frame can state a chapter’s beginning
+	///    and end: by milliseconds or by byte offset, accessible here as
+	///    StartMilliseconds/EndMilliseconds and StartByteOffset/EndByteOffset
+	///    respectively. The byte offsets are the zero-based byte positions of
+	///    the first audio frame in the chapter or the first audio frame folliwing
+	///    the chapter, counted from the beginning of the file. The byte offsets
+	///    are to be ignored according to the spec if they are FF FF FF FF. This
+	///    class does not synchronize the two ways in any way, so make sure to set
+	///    both appropriately. The byte offsets are however initialized to be
+	///    ignored, so with blank frames, you can focus on the milliseconds.
+	///
+	///    According to the spec, chapters may overlap and have gaps.
+	/// </remarks>
+	public class ChapterFrame : Frame
+	{
+		#region Constructors
+
+		/// <summary>
+		///    Constructs and initializes a new empty instance of <see
+		///    cref="ChapterFrame" />.
+		/// </summary>
+		public ChapterFrame ()
+			: base(FrameType.CHAP, 4)
+		{
+		}
+
+		/// <summary>
+		///    Constructs and initializes a new empty instance of <see
+		///    cref="ChapterFrame" /> with the given chapter ID.
+		/// </summary>
+		public ChapterFrame (string id)
+			: this()
+		{
+			Id = id;
+		}
+
+		/// <summary>
+		///    Constructs and initializes a new instance of <see cref="ChapterFrame" />
+		///    with the given chapter ID and adds a <see cref="TextInformationFrame"/>
+		///    "<c>TIT2</c>" with the given title.
+		/// </summary>
+		public ChapterFrame (string id, string title)
+			: this(id)
+		{
+			SubFrames.Add(new TextInformationFrame("TIT2") { Text = new[] { title } });
+		}
+
+		/// <summary>
+		///    Constructs and initializes a new instance of <see
+		///    cref="ChapterFrame" /> by reading its raw data in a
+		///    specified ID3v2 version.
+		/// </summary>
+		/// <param name="data">
+		///    A <see cref="ByteVector" /> object starting with the raw
+		///    representation of the new frame.
+		/// </param>
+		/// <param name="version">
+		///    A <see cref="byte" /> indicating the ID3v2 version the
+		///    raw frame is encoded in.
+		/// </param>
+		public ChapterFrame (ByteVector data, byte version)
+			: base (data, version)
+		{
+			SetData (data, 0, version, true);
+		}
+
+		/// <summary>
+		///    Constructs and initializes a new instance of <see
+		///    cref="ChapterFrame" /> by reading its raw data in a
+		///    specified ID3v2 version.
+		/// </summary>
+		/// <param name="data">
+		///    A <see cref="ByteVector" /> object containing the raw
+		///    representation of the new frame.
+		/// </param>
+		/// <param name="offset">
+		///    A <see cref="int" /> indicating at what offset in
+		///    <paramref name="data" /> the frame actually begins.
+		/// </param>
+		/// <param name="header">
+		///    A <see cref="FrameHeader" /> containing the header of the
+		///    frame found at <paramref name="offset" /> in the data.
+		/// </param>
+		/// <param name="version">
+		///    A <see cref="byte" /> indicating the ID3v2 version the
+		///    raw frame is encoded in.
+		/// </param>
+		protected internal ChapterFrame (ByteVector data, int offset, FrameHeader header, byte version)
+			: base (header)
+		{
+			SetData (data, offset, version, false);
+		}
+
+		#endregion
+
+
+		#region Public Properties
+
+		/// <summary>
+		///    Gets and sets the internal chapter id. This should be
+		///    <see cref="StringType.Latin1" /> .
+		/// </summary>
+		public string Id { get; set; }
+
+		/// <summary>
+		///    Gets and sets the start time of the chapter in milliseconds.
+		/// </summary>
+		public uint StartMilliseconds { get; set; }
+
+		/// <summary>
+		///    Gets and sets the end time of the chapter in milliseconds.
+		/// </summary>
+		public uint EndMilliseconds { get; set; }
+
+		/// <summary>
+		///    Gets and sets the chapter’s first audio frame’s byte position
+		///    from the beginning of the file.
+		///    The spec makes this ignorable if it is FF FF FF FF, which is
+		///    the initial value.
+		/// </summary>
+		public uint StartByteOffset { get; set; } = 0xFFFFFFFF;
+
+		/// <summary>
+		///    Gets and sets the byte position of the first audio frame following
+		///    the chapter from the beginning of the file.
+		///    The spec makes this ignorable if it is FF FF FF FF, which is
+		///    the initial value.
+		/// </summary>
+		public uint EndByteOffset { get; set; } = 0xFFFFFFFF;
+
+		/// <summary>
+		///    Gets and sets the descriptive sub-fields for this chapter. It
+		///    is recommended by the spec to have at least a "<c>TIT2</c>"
+		///    <see cref="TextInformationFrame"/> with the chapter title, but
+		///    it can contain anything. Particularly, players like to display
+		///    per-chapter "<c>APIC</c>" <see cref="AttachmentFrame"/>s and
+		///    <see cref="UrlLinkFrame"/>s.
+		/// </summary>
+		/// <value>
+		///    A List of arbitrary <see cref="Frame" />s.
+		/// </value>
+		public List<Frame> SubFrames { get; set; } = new List<Frame>();
+
+		#endregion
+
+
+		#region Protected Methods
+
+		/// <summary>
+		///    Populates the values in the current instance by parsing
+		///    its field data in a specified version.
+		/// </summary>
+		/// <param name="data">
+		///    A <see cref="ByteVector" /> object containing the
+		///    extracted field data.
+		/// </param>
+		/// <param name="version">
+		///    A <see cref="byte" /> indicating the ID3v2 version the
+		///    field data is encoded in.
+		/// </param>
+		protected override void ParseFields (ByteVector data, byte version)
+		{
+			// https://id3.org/id3v2-chapters-1.0
+
+			int idLength = data.IndexOf((byte)0) + 1;
+
+			Id                = data.ToString(StringType.Latin1, 0, idLength - 1); //Always Latin1, at least there is no mention of encoding in the spec
+			StartMilliseconds = data.Mid(idLength,      4).ToUInt();
+			EndMilliseconds   = data.Mid(idLength +  4, 4).ToUInt();
+			StartByteOffset   = data.Mid(idLength +  8, 4).ToUInt(); //I don’t really know why one would use the offsets.
+			EndByteOffset     = data.Mid(idLength + 12, 4).ToUInt(); //They are to be ignored if all 4 Bytes are FF, i.e. 4,294,967,295.
+
+			SubFrames = new List<Frame>();
+			int frame_data_position = idLength + 16;
+			int frame_data_endposition = data.Count;
+			while (frame_data_position < frame_data_endposition)
+			{
+				Frame frame;
+				try
+				{
+					frame = FrameFactory.CreateFrame(data, null, ref frame_data_position, version, true /* ? */);
+				}
+				catch (NotImplementedException)
+				{
+					continue;
+				}
+				catch (CorruptFileException)
+				{
+					throw;
+				}
+
+				if (frame == null)
+					break;
+
+				// Only add frames that contain data.
+				if (frame.Size == 0)
+					continue;
+
+				SubFrames.Add(frame);
+			}
+		}
+
+		/// <summary>
+		///    Renders the values in the current instance into field
+		///    data for a specified version.
+		/// </summary>
+		/// <param name="version">
+		///    A <see cref="byte" /> indicating the ID3v2 version the
+		///    field data is to be encoded in.
+		/// </param>
+		/// <returns>
+		///    A <see cref="ByteVector" /> object containing the
+		///    rendered field data.
+		/// </returns>
+		protected override ByteVector RenderFields (byte version)
+		{
+			var data = ByteVector.FromString(Id, StringType.Latin1);
+			data.Add((byte)0); //it would be neat if Add were chainable…
+			data.Add(ByteVector.FromUInt(StartMilliseconds));
+			data.Add(ByteVector.FromUInt(EndMilliseconds));
+			data.Add(ByteVector.FromUInt(StartByteOffset));
+			data.Add(ByteVector.FromUInt(EndByteOffset));
+
+			foreach (var f in SubFrames)
+				data.Add(f.Render(version));
+
+			return data;
+		}
+
+		#endregion
+	}
+}

--- a/src/TaglibSharp/Id3v2/Frames/TableOfContentsFrame.cs
+++ b/src/TaglibSharp/Id3v2/Frames/TableOfContentsFrame.cs
@@ -265,5 +265,32 @@ namespace TagLib.Id3v2
 		}
 
 		#endregion
+
+
+		#region ICloneable
+
+		/// <summary>
+		///    Creates a deep copy of the current instance.
+		/// </summary>
+		/// <returns>
+		///    A new <see cref="Frame" /> object identical to the
+		///    current instance.
+		/// </returns>
+		public override Frame Clone()
+		{
+			var frame = new TableOfContentsFrame(Id);
+			frame.IsTopLevel = IsTopLevel;
+			frame.IsOrdered = IsOrdered;
+
+			foreach (var c in ChapterIds)
+				frame.ChapterIds.Add(c);
+
+			foreach (var f in SubFrames)
+				frame.SubFrames.Add(f.Clone());
+
+			return frame;
+		}
+
+		#endregion
 	}
 }

--- a/src/TaglibSharp/Id3v2/Frames/TableOfContentsFrame.cs
+++ b/src/TaglibSharp/Id3v2/Frames/TableOfContentsFrame.cs
@@ -1,0 +1,269 @@
+using System;
+using System.Collections.Generic;
+
+namespace TagLib.Id3v2
+{
+	/// <summary>
+	///    This class extends <see cref="Frame" /> to provide support for
+	///    Table of Contents Frames, i.e. "<c>CTOC</c>",
+	///    (ID3v2 Chapter Frame Addendum 1.0, https://id3.org/id3v2-chapters-1.0).
+	/// </summary>
+	/// <remarks>
+	///    The <see cref="TableOfContentsFrame"/> is special in that it can hold
+	///    an arbitrary amount of sub-frames, which are made available here as a
+	///    List of <see cref="Frame"/>s in the property <see cref="SubFrames"/>.
+	///    
+	///    A tag may contain multiple <see cref="TableOfContentsFrame"/>s, there
+	///    may however be only one top-level "<c>CTOC</c>" as stated by the
+	///    property <see cref="IsTopLevel"/>.
+	///
+	///    Each <see cref="TableOfContentsFrame"/> must have an identifying string
+	///    that is unique across all <see cref="TableOfContentsFrame"/>s and
+	///    <see cref="ChapterFrame"/>s in the tag. This is the <see cref="Id"/>
+	///    property. It is not intended for humans and players will not display it.
+	///    For humans, add a "<c>TIT2</c>" <see cref="TextInformationFrame"/>.
+	/// </remarks>
+	public class TableOfContentsFrame : Frame
+	{
+		[System.Flags]
+		private enum CTOCFlags : byte
+		{
+			TopLevel = 1,
+			Ordered  = 2
+		}
+
+
+		#region Constructors
+
+		/// <summary>
+		///    Constructs and initializes a new empty instance of <see
+		///    cref="TableOfContentsFrame" />.
+		/// </summary>
+		public TableOfContentsFrame ()
+			: base (FrameType.CTOC, 4)
+		{
+		}
+
+		/// <summary>
+		///    Constructs and initializes a new empty instance of <see
+		///    cref="TableOfContentsFrame" /> with the given TOC Id.
+		/// </summary>
+		public TableOfContentsFrame(string id)
+			: this()
+		{
+			Id = id;
+		}
+
+		/// <summary>
+		///    Constructs and initializes a new instance of <see
+		///    cref="TableOfContentsFrame" /> with the given TOC Id
+		///    and adds a TIT2 <see cref="TextInformationFrame"/>
+		///    with the given title.
+		/// </summary>
+		public TableOfContentsFrame(string id, string title)
+			: this(id)
+		{
+			SubFrames.Add(new TextInformationFrame("TIT2") { Text = new[] { title } });
+		}
+
+		/// <summary>
+		///    Constructs and initializes a new instance of <see
+		///    cref="TableOfContentsFrame" /> by reading its raw data in
+		///    a specified ID3v2 version.
+		/// </summary>
+		/// <param name="data">
+		///    A <see cref="ByteVector" /> object starting with the raw
+		///    representation of the new frame.
+		/// </param>
+		/// <param name="version">
+		///    A <see cref="byte" /> indicating the ID3v2 version the
+		///    raw frame is encoded in.
+		/// </param>
+		public TableOfContentsFrame (ByteVector data, byte version)
+			: base (data, version)
+		{
+			SetData (data, 0, version, true);
+		}
+
+		/// <summary>
+		///    Constructs and initializes a new instance of <see
+		///    cref="TableOfContentsFrame" /> by reading its raw data in a
+		///    specified ID3v2 version.
+		/// </summary>
+		/// <param name="data">
+		///    A <see cref="ByteVector" /> object containing the raw
+		///    representation of the new frame.
+		/// </param>
+		/// <param name="offset">
+		///    A <see cref="int" /> indicating at what offset in
+		///    <paramref name="data" /> the frame actually begins.
+		/// </param>
+		/// <param name="header">
+		///    A <see cref="FrameHeader" /> containing the header of the
+		///    frame found at <paramref name="offset" /> in the data.
+		/// </param>
+		/// <param name="version">
+		///    A <see cref="byte" /> indicating the ID3v2 version the
+		///    raw frame is encoded in.
+		/// </param>
+		protected internal TableOfContentsFrame (ByteVector data, int offset, FrameHeader header, byte version)
+			: base (header)
+		{
+			SetData (data, offset, version, false);
+		}
+
+		#endregion
+
+
+		#region Public Properties
+
+		/// <summary>
+		///    Gets and sets the internal table of contents id.
+		///    This should be <see cref="StringType.Latin1" />
+		///    and must be unique with respect to any other
+		///    "<c>CTOC</c>" or "<c>CHAP</c>" frame in the tag.
+		/// </summary>
+		public string Id { get; set; }
+
+		/// <summary>
+		///    Gets and sets the boolean stating that this is the root
+		///    of all "<c>CTOC</c>"s. As such there must be only one
+		///    "<c>CTOC</c>" with this set to true.
+		/// </summary>
+		public bool IsTopLevel { get; set; }
+
+		/// <summary>
+		///    Gets and sets the boolean stating that this table of
+		///    contents’ chapters should be played in order.
+		/// </summary>
+		public bool IsOrdered { get; set; }
+
+		/// <summary>
+		///    Gets and sets the list of chapters in this table of contents
+		///    identified by their <see cref="ChapterFrame.Id"/>s.
+		///    Because the number of chapters is stored in this frame using
+		///    only one byte for parsing purposes, this should not contain
+		///    more than 255 chapters.
+		/// </summary>
+		public List<string> ChapterIds { get; set; } = new List<string>();
+
+		/// <summary>
+		///    Gets and sets the descriptive sub-fields for this chapter. It
+		///    is recommended by the spec to have at least a "<c>TIT2</c>"
+		///    <see cref="TextInformationFrame"/> with the chapter title, but
+		///    it can contain anything.
+		/// </summary>
+		/// <value>
+		///    A List of arbitrary <see cref="Frame" />s.
+		/// </value>
+		public List<Frame> SubFrames { get; set; } = new List<Frame>();
+
+		#endregion
+
+
+		#region Protected Methods
+
+		/// <summary>
+		///    Populates the values in the current instance by parsing
+		///    its field data in a specified version.
+		/// </summary>
+		/// <param name="data">
+		///    A <see cref="ByteVector" /> object containing the
+		///    extracted field data.
+		/// </param>
+		/// <param name="version">
+		///    A <see cref="byte" /> indicating the ID3v2 version the
+		///    field data is encoded in.
+		/// </param>
+		protected override void ParseFields (ByteVector data, byte version)
+		{
+			// https://id3.org/id3v2-chapters-1.0
+
+			int idLength = data.IndexOf((byte)0) + 1;
+			Id  = data.ToString(StringType.Latin1, 0, idLength - 1);
+
+			var flags = (CTOCFlags)data[idLength]; //Flags %000000ab Entry count $xx (8-bit unsigned int)
+			IsTopLevel = flags.HasFlag(CTOCFlags.TopLevel); //a
+			IsOrdered = flags.HasFlag(CTOCFlags.Ordered); //b
+
+			var chapterCount = data[idLength + 1]; //Entry count $xx (8-bit unsigned int)
+
+			if (data.Count <= idLength + 2)
+				return; //no chapter ids and no subframes
+
+			/* Get chapter ids according to the chapterCount byte.
+			 * Anything left after that should be subframes.
+			 * TODO: If there are more chapters than fit inside
+			 * the chapterCount byte, I guess the file is malformed?
+			 */
+			int position = idLength + 2;
+			for (int i = 0; i < chapterCount; i++)
+			{
+				int nextPosition = data.Find((byte)0, position) + 1;
+				ChapterIds.Add(data.Mid(position, nextPosition-position-1).ToString(StringType.Latin1));
+				position = nextPosition;
+			}
+
+			SubFrames = new List<Frame>();
+			int frame_data_endposition = data.Count;
+			while (position < frame_data_endposition)
+			{
+				Frame frame;
+				try
+				{
+					frame = FrameFactory.CreateFrame(data, null, ref position, version, true /* ? */);
+				}
+				catch (NotImplementedException)
+				{
+					continue;
+				}
+				catch (CorruptFileException)
+				{
+					throw;
+				}
+
+				if (frame == null)
+					break;
+
+				// Only add frames that contain data.
+				if (frame.Size == 0)
+					continue;
+
+				SubFrames.Add(frame);
+			}
+		}
+
+		/// <summary>
+		///    Renders the values in the current instance into field
+		///    data for a specified version.
+		/// </summary>
+		/// <param name="version">
+		///    A <see cref="byte" /> indicating the ID3v2 version the
+		///    field data is to be encoded in.
+		/// </param>
+		/// <returns>
+		///    A <see cref="ByteVector" /> object containing the
+		///    rendered field data.
+		/// </returns>
+		protected override ByteVector RenderFields (byte version)
+		{
+			var data = ByteVector.FromString(Id, StringType.Latin1);
+			data.Add((byte)0);
+			data.Add((byte)((IsTopLevel ? CTOCFlags.TopLevel : 0) | (IsOrdered ? CTOCFlags.Ordered : 0)));
+			data.Add(ChapterIds.Count >= byte.MaxValue ? byte.MaxValue /*TODO: throw?*/ : (byte)ChapterIds.Count);
+
+			foreach(var chap in ChapterIds)
+			{
+				data.Add(ByteVector.FromString(chap, StringType.Latin1));
+				data.Add((byte)0);
+			}
+
+			foreach (var f in SubFrames)
+				data.Add(f.Render(version));
+
+			return data;
+		}
+
+		#endregion
+	}
+}


### PR DESCRIPTION
Hi. This is sort of rudimentary. Ideally I would like to expose the chapters directly from the File’s Tag property and have TagLib handle the internals like generating ids and enforcing uniqueness, but it’s been working fine for me going through `(TagLib.Id3v2.Tag)File.GetTag(TagLib.TagTypes.Id3v2)` and setting the frames up manually.

