### PR TITLE
Fixed: Corrupting OPUS files on write

### DIFF
--- a/src/TaglibSharp.Tests/FileFormats/OpusFormatTest.cs
+++ b/src/TaglibSharp.Tests/FileFormats/OpusFormatTest.cs
@@ -67,5 +67,28 @@ namespace TaglibSharp.Tests.FileFormats
 		{
 			StandardTests.TestCorruptionResistance (TestPath.Samples + "corrupt/a.opus");
 		}
+
+		[Test]
+		public void CheckInvariantStartPosition()
+		{
+			// There was a corruption bug in OPUS file writer, the root cause of which was
+			// the Ogg Bitstream class requiring the first page of the media data to be read
+			// in order to process the tags.  Then on write this media page is incorrectly
+			// replaced with a page with absoluteGranularPosition = 0, which is not allowed.
+			//
+			// The sample file has the media beginning in the third page.  To test the fix
+			// ensure that the InvariantStartPosition is the location of the third page.
+			// Previously we read/wrote the third page and corrupted it, and InvariantStartPosition
+			// was set to the start of the fourth page.
+			//
+			// In principle the comments packet can span multiple pages, so if the test file
+			// is updated in future this may need adjusting.
+
+			var p1 = file.Find("OggS", 0);
+			var p2 = file.Find("OggS", p1 + 1);
+			var p3 = file.Find("OggS", p2 + 1);
+
+			Assert.AreEqual(p3, file.InvariantStartPosition);
+		}
 	}
 }

--- a/src/TaglibSharp/Ogg/Bitstream.cs
+++ b/src/TaglibSharp/Ogg/Bitstream.cs
@@ -119,14 +119,6 @@ namespace TagLib.Ogg
 			ByteVector[] packets = page.Packets;
 
 			for (int i = 0; i < packets.Length; i++) {
-				if ((page.Header.Flags &
-					PageFlags.FirstPacketContinued) == 0 &&
-					previous_packet != null) {
-					if (ReadPacket (previous_packet))
-						return true;
-					previous_packet = null;
-				}
-
 
 				ByteVector packet = packets[i];
 
@@ -142,9 +134,9 @@ namespace TagLib.Ogg
 
 				previous_packet = null;
 
-				if (i == packets.Length - 1) {
+				if (i == packets.Length - 1 && !page.Header.LastPacketComplete) {
 					// If we're at the last packet of the
-					// page, store it.
+					// page and it's continued on the next page, store it.
 					previous_packet = new ByteVector (packet);
 				} else if (ReadPacket (packet)) {
 					// Otherwise, we need to process it.

--- a/src/TaglibSharp/Ogg/PageHeader.cs
+++ b/src/TaglibSharp/Ogg/PageHeader.cs
@@ -115,6 +115,7 @@ namespace TagLib.Ogg
 			Size = 0;
 			DataSize = 0;
 			packet_sizes = new List<int> ();
+			LastPacketComplete = false;
 
 			if (pageNumber == 0 && (flags & PageFlags.FirstPacketContinued) == 0)
 				Flags |= PageFlags.FirstPageOfStream;
@@ -200,6 +201,8 @@ namespace TagLib.Ogg
 
 			if (packet_size > 0)
 				packet_sizes.Add (packet_size);
+
+			LastPacketComplete = page_segments[page_segment_count - 1] < 255;
 		}
 
 		/// <summary>
@@ -230,6 +233,7 @@ namespace TagLib.Ogg
 			Size = original.Size;
 			DataSize = original.DataSize;
 			packet_sizes = new List<int> ();
+			LastPacketComplete = false;
 
 			if (PageSequenceNumber == 0 && (flags & PageFlags.FirstPacketContinued) == 0)
 				Flags |= PageFlags.FirstPageOfStream;
@@ -257,12 +261,20 @@ namespace TagLib.Ogg
 		}
 
 		/// <summary>
-		///    Gets the flags for the page described by the current
-		///    instance.
+		///	   Indicates whether the final packet is continued on the next page
 		/// </summary>
 		/// <value>
-		///    A <see cref="PageFlags" /> value containing the page
-		///    flags.
+		///	   true if the final packet is complete and not continued on the next page
+		/// </value>
+		public bool LastPacketComplete { get; private set; }
+
+		/// <summary>
+		///	   Gets the flags for the page described by the current
+		///	   instance.
+		/// </summary>
+		/// <value>
+		///	   A <see cref="PageFlags" /> value containing the page
+		///	   flags.
 		/// </value>
 		public PageFlags Flags { get; private set; }
 


### PR DESCRIPTION
There is a corruption bug in OPUS file writer, see https://github.com/mono/taglib-sharp/issues/221

The root cause is that the Ogg `Bitstream` class assumes that the final packet of any page is incomplete, and so reads the next page (the first media page) and looks at the `PageFlag.FirstPacketContinued` flag to determine what to do.  This means it's marking the first media page as part of the "variant" section and rewriting it i.e. `InvariantStartPosition` is one page later than it should be.  

When it re-writes the first media page, it generates a new `Page` and `PageHeader` with the `AbsoluteGranualarPosition` set to `0`, but this is not allowed in an Opus media page - it should be:
> the total number of PCM samples in the stream up to and including the last fully decodable sample from the last packet completed on that page
https://tools.ietf.org/html/rfc7845#section-4

I have fixed this by making `Bitstream` look at the lacing values in the segment table in the page header to determine if the final packet in the page is complete.  If the final lacing value is `<255` then the packet is complete.  If it is `255` then it will be continued in the next page (where in principle it could be terminated by a lacing value of `0`).  Documentation is here:
https://www.xiph.org/vorbis/doc/framing.html

In particular (highlighting mine):
>Packets are not restricted to beginning and ending within a page, although individual segments are, by definition, required to do so. Packets are not restricted to a maximum size, although excessively large packets in the data stream are discouraged; the Ogg bitstream specification strongly recommends nominal page size of approximately 4-8kB (large packets are foreseen as being useful for initialization data at the beginning of a logical bitstream).
>
>After segmenting a packet, the encoder may decide not to place all the resulting segments into the current page; to do so, the encoder places the lacing values of the segments it wishes to belong to the current page into the current segment table, then finishes the page. The next page is begun with the first value in the segment table belonging to the next packet segment, thus continuing the packet (data in the packet body must also correspond properly to the lacing values in the spanned pages. The segment data in the first packet corresponding to the lacing values of the first page belong in that page; packet segments listed in the segment table of the following page must begin the page body of the subsequent page).
>
>The last mechanic to spanning a page boundary is to set the header flag in the new page to indicate that the first lacing value in the segment table continues rather than begins a packet; **a header flag of 0x01 is set to indicate a continued packet. Although mandatory, it is not actually algorithmically necessary; one could inspect the preceding segment table to determine if the packet is new or continued.** Adding the information to the packet_header flag allows a simpler design (with no overhead) that needs only inspect the current page header after frame capture. This also allows faster error recovery in the event that the packet originates in a corrupt preceding page, implying that the previous page's segment table cannot be trusted.
>
>Note that a packet can span an arbitrary number of pages; the above spanning process is repeated for each spanned page boundary. Also a 'zero termination' on a packet size that is an even multiple of 255 must appear even if the lacing value appears in the next page as a zero-length continuation of the current packet. The header flag should be set to 0x01 to indicate that the packet spanned, even though the span is a nil case as far as data is concerned.

The test is to check that the `InvariantStartPosition` is correct.  In the sample file, it should be the beginning of the 3rd page i.e. the 3rd instance of `OggS` in the file.  Currently it's set to the beginning of the 4th page - applying the new test with the current code will fail.