### PR TITLE
MPEG Audio Header Offset Calculation

### DIFF
--- a/src/TaglibSharp.Tests/FileFormats/MpgFormatTest.cs
+++ b/src/TaglibSharp.Tests/FileFormats/MpgFormatTest.cs
@@ -24,9 +24,19 @@ namespace TaglibSharp.Tests.FileFormats
 		[Test]
 		public void ReadAudioProperties ()
 		{
+			Assert.AreEqual (128, file.Properties.AudioBitrate);
+			Assert.AreEqual (2, file.Properties.AudioChannels);
 			Assert.AreEqual (44100, file.Properties.AudioSampleRate);
 			// NOTE, with .net core it keeps the decimal places. So, for now, we round to match .net behavior
 			Assert.AreEqual (1391, Math.Round (file.Properties.Duration.TotalMilliseconds));
+
+		}
+
+		[Test]
+		public void ReadVideoProperties ()
+		{
+			Assert.AreEqual (480, file.Properties.VideoHeight);
+			Assert.AreEqual (640, file.Properties.VideoWidth);
 		}
 
 
@@ -68,7 +78,7 @@ namespace TaglibSharp.Tests.FileFormats
 
 			file.Save ();
 
-			// Read back the Matroska-specific tags 
+			// Read back the Matroska-specific tags
 			file = File.Create (tmp_file);
 			Assert.NotNull (file);
 			pics = file.Tag.Pictures;


### PR DESCRIPTION
**Description**: While working on my port of TagLib# to node, I added a test case to validate that the Turning Lime sample video was being decoded with the correct audio properties. I noticed that the audio bitrate wasn't decoded correctly compared to output from FFMpeg. With some help from http://andrewduncan.net/mpeg/mpeg-1.html and some digging in a hex editor, I figured out that the original implementation assumes there is always 16 "stuffing bytes" before the packet data begins. In the case of the turning lime file, there aren't any stuffing bytes (always 0xFF), so when the audio header is searched for, the correct header is skipped over and something that kinda looks like an audio header (ie, starts with 0xFF, >=0xE0) is decoded instead. This returns an audio bitrate of 192 instead of 128 and a version of MPEG-1 layer 1 instead of MPEG-1 layer 2. 

This PR updates the audio header detection to start at the correct end of the packet header. Rather than assuming 16 stuffing bytes, the correct number for the packet are read. After that, the PTS and DTS flags are decoded and the corresponding bytes are skipped over. Finally, `AudioHeader.find` is called with the offset set to the calculated offset where the packet data begins.

I also added in a couple more test cases to make sure all the available audio/video properties were read in correctly.

**Testing**:
* Added new unit test cases to MPEG file formats 
  * to check audio properties ✔️ 
  * to check video properties ✔️ 