### PR TITLE
Adding extended precision ByteVector conversion for AIFF sample rate

### DIFF
--- a/src/TaglibSharp/Aiff/StreamHeader.cs
+++ b/src/TaglibSharp/Aiff/StreamHeader.cs
@@ -66,7 +66,7 @@ namespace TagLib.Aiff
 		/// </summary>
 		/// <remarks>
 		///    This value is stored in bytes (17-26).
-		///    the sample rate at which the sound is to be played back, 
+		///    the sample rate at which the sound is to be played back,
 		///    in sample frames per second
 		/// </remarks>
 		readonly ulong sample_rate;
@@ -120,7 +120,7 @@ namespace TagLib.Aiff
 		/// </exception>
 		/// <exception cref="CorruptFileException">
 		///    <paramref name="data" /> does not begin with <see
-		///    cref="FileIdentifier" /> 
+		///    cref="FileIdentifier" />
 		/// </exception>
 		public StreamHeader (ByteVector data, long streamLength)
 		{
@@ -138,54 +138,7 @@ namespace TagLib.Aiff
 			channels = data.Mid (8, 2).ToUShort (true);
 			total_frames = data.Mid (10, 4).ToULong (true);
 			bits_per_sample = data.Mid (14, 2).ToUShort (true);
-
-			ByteVector sample_rate_indicator = data.Mid (17, 1);
-			ulong sample_rate_tmp = data.Mid (18, 2).ToULong (true);
-			sample_rate = 44100; // Set 44100 as default sample rate
-
-			// The following are combinations that iTunes 8 encodes to.
-			// There may be other combinations in the field, but i couldn't test them.
-			switch (sample_rate_tmp) {
-			case 44100:
-				if (sample_rate_indicator == 0x0E) {
-					sample_rate = 44100;
-				} else if (sample_rate_indicator == 0x0D) {
-					sample_rate = 22050;
-				} else if (sample_rate_indicator == 0x0C) {
-					sample_rate = 11025;
-				}
-				break;
-
-			case 48000:
-				if (sample_rate_indicator == 0x0E) {
-					sample_rate = 48000;
-				} else if (sample_rate_indicator == 0x0D) {
-					sample_rate = 24000;
-				}
-				break;
-
-			case 64000:
-				if (sample_rate_indicator == 0x0D) {
-					sample_rate = 32000;
-				} else if (sample_rate_indicator == 0x0C) {
-					sample_rate = 16000;
-				} else if (sample_rate_indicator == 0x0B) {
-					sample_rate = 8000;
-				}
-				break;
-
-			case 44510:
-				if (sample_rate_indicator == 0x0D) {
-					sample_rate = 22255;
-				}
-				break;
-
-			case 44508:
-				if (sample_rate_indicator == 0x0C) {
-					sample_rate = 11127;
-				}
-				break;
-			}
+			sample_rate = (ulong)data.Mid (16, 10).ToExtendedPrecision ();
 		}
 
 		#endregion

--- a/src/TaglibSharp/ByteVector.cs
+++ b/src/TaglibSharp/ByteVector.cs
@@ -757,7 +757,7 @@ namespace TagLib
 				patternLength = pattern.Count;
 			}
 
-			// do some sanity checking -- all of these things are 
+			// do some sanity checking -- all of these things are
 			// needed for the search to be valid
 			if (patternLength > data.Count ||
 				offset >= data.Count ||
@@ -1396,6 +1396,43 @@ namespace TagLib
 		public double ToDouble ()
 		{
 			return ToDouble (true);
+		}
+
+		/// <summary>
+		///    Converts the first 10 bytes of the current instance to an IEEE
+		///    754 80-bit extended precision floating point number, expressed
+		///    as a <see cref="double"/>.
+		/// </summary>
+		/// <returns>
+		///    A <see cref="double"/> value containing the value read from the
+		///    current instance.
+		/// </returns>
+		public double ToExtendedPrecision ()
+		{
+			int exponent = ((this[0] & 0x7F) << 8) | this[1];
+			ulong hiMantissa = ((ulong)this[2] << 24)
+			                   | ((ulong)this[3] << 16)
+			                   | ((ulong)this[4] << 8)
+			                   | this[5];
+			ulong loMantissa = ((ulong)this[6] << 24)
+			                   | ((ulong)this[7] << 16)
+			                   | ((ulong)this[8] << 8)
+			                   | this[9];
+
+			double f;
+			if (exponent == 0 && hiMantissa == 0 && loMantissa == 0) {
+				f = 0;
+			} else {
+				if (exponent == 0x7FFF) {
+					f = double.PositiveInfinity;
+				} else {
+					exponent -= 16383;
+					f = hiMantissa * Math.Pow (2, exponent -= 31);
+					f += loMantissa * Math.Pow (2, exponent -= 32);
+				}
+			}
+
+			return (this[0] & 0x80) != 0 ? -f : f;
 		}
 
 		/// <summary>


### PR DESCRIPTION
**Description**: During my port of taglib# to node, I noticed a long string of logic for determining the sample rate for AIFF files. Since it's not uncommon for sample rates to be stored in a table, I didn't think much of it. However, while working on writing unit tests for the `Aiff.StremHeader` class, I wanted to double check the AIFF spec to see if there were any more sample rates, since it seemed odd that AIFF could only support a max sample rate of 64kHz when 96kHz and 192kHz files are all the rage these days. Turns out the AIFF spec uses an 80-bit IEEE 754 extended precision floating point number for storing the sample rate (http://muratnkonar.com/aiff/index.html), not a lookup table of sample rates. What's more, I've seen Apple users mention that 96kHz AIFF files exist (https://discussions.apple.com/thread/7273841). Therefore, the existing logic is going to give faulty duration and sample rate values for AIFF files with sample rates > 64kHz.

The proposed solution in this PR is to add logic for converting a `ByteVector` into a IEEE 754 extended precision floating point value, expressed as a double. The `Aiff.StreamHeader` class has been updated to use this to get the full sample rate. The basis for this logic was from http://www33146ue.sakura.ne.jp/staff/iz/formats/ieee.c

Since this is the only usage of this new method, I'm open to storing it somewhere other than the `ByteVector` class.

**Testing**: 
* Existing tests for AIFF continue to work.
* I feel like there should be thorough tests of the new `ByteVector` method, but I'm not entirely sure how to fit it into the existing set of tests for the class. Any suggestions would be welcome.