### PR TITLE
ASF Duration Calculation Fix, Creation Date Fix

### DIFF
--- a/src/TaglibSharp.Tests/FileFormats/AsfFormatTest.cs
+++ b/src/TaglibSharp.Tests/FileFormats/AsfFormatTest.cs
@@ -1,3 +1,4 @@
+using System;
 using NUnit.Framework;
 using TagLib;
 
@@ -19,7 +20,12 @@ namespace TaglibSharp.Tests.FileFormats
 		[Test]
 		public void ReadAudioProperties ()
 		{
-			StandardTests.ReadAudioProperties (file);
+			Assert.AreEqual (96, file.Properties.AudioBitrate);
+			Assert.AreEqual (2, file.Properties.AudioChannels);
+			Assert.AreEqual (44100, file.Properties.AudioSampleRate);
+			// NOTE, with .net core it keeps the decimal places. So, for now, we round to match .net behavior
+			Assert.AreEqual (4153, Math.Round(file.Properties.Duration.TotalMilliseconds));
+			Assert.AreEqual (MediaTypes.Audio, file.Properties.MediaTypes);
 		}
 
 		[Test]

--- a/src/TaglibSharp/Asf/FilePropertiesObject.cs
+++ b/src/TaglibSharp/Asf/FilePropertiesObject.cs
@@ -6,7 +6,7 @@
 //   Brian Nickel (brian.nickel@gmail.com)
 //
 // Copyright (C) 2006-2007 Brian Nickel
-// 
+//
 // This library is free software; you can redistribute it and/or modify
 // it  under the terms of the GNU Lesser General Public License version
 // 2.1 as published by the Free Software Foundation.
@@ -33,6 +33,12 @@ namespace TagLib.Asf
 	/// </summary>
 	public class FilePropertiesObject : Object
 	{
+		#region Constant Values
+
+		static readonly DateTime FileTimeOffset = new DateTime (1601, 1, 1);
+
+		#endregion
+
 		#region Private Fields
 
 		/// <summary>
@@ -98,8 +104,8 @@ namespace TagLib.Asf
 			FileSize = file.ReadQWord ();
 			creation_date = file.ReadQWord ();
 			DataPacketsCount = file.ReadQWord ();
-			send_duration = file.ReadQWord ();
 			play_duration = file.ReadQWord ();
+			send_duration = file.ReadQWord ();
 			Preroll = file.ReadQWord ();
 			Flags = file.ReadDWord ();
 			MinimumDataPacketSize = file.ReadDWord ();
@@ -144,7 +150,7 @@ namespace TagLib.Asf
 		///    date of the file described by the current instance.
 		/// </value>
 		public DateTime CreationDate {
-			get { return new DateTime ((long)creation_date); }
+			get { return new DateTime ((long)creation_date + FileTimeOffset.Ticks); }
 		}
 
 		/// <summary>
@@ -253,8 +259,8 @@ namespace TagLib.Asf
 			output.Add (RenderQWord (FileSize));
 			output.Add (RenderQWord (creation_date));
 			output.Add (RenderQWord (DataPacketsCount));
-			output.Add (RenderQWord (send_duration));
 			output.Add (RenderQWord (play_duration));
+			output.Add (RenderQWord (send_duration));
 			output.Add (RenderQWord (Preroll));
 			output.Add (RenderDWord (Flags));
 			output.Add (RenderDWord (MinimumDataPacketSize));

--- a/src/TaglibSharp/Asf/HeaderObject.cs
+++ b/src/TaglibSharp/Asf/HeaderObject.cs
@@ -6,7 +6,7 @@
 //   Brian Nickel (brian.nickel@gmail.com)
 //
 // Copyright (C) 2006-2007 Brian Nickel
-// 
+//
 // This library is free software; you can redistribute it and/or modify
 // it  under the terms of the GNU Lesser General Public License version
 // 2.1 as published by the Free Software Foundation.
@@ -144,7 +144,7 @@ namespace TagLib.Asf
 
 				foreach (var obj in Children) {
 					if (obj is FilePropertiesObject fpobj) {
-						duration = fpobj.PlayDuration - new TimeSpan ((long)fpobj.Preroll);
+						duration = fpobj.PlayDuration - TimeSpan.FromMilliseconds (fpobj.Preroll);
 						continue;
 					}
 


### PR DESCRIPTION
**Description**: Another couple bugs I found while porting ASF support in TagLib# to node 😅

The TagLib# implementation of ASF duration wasn't calculating the same duration for the sample.wma file as FFMpeg, foobar2000, VLC, which all said the file was 0:04 (or 4.153s). TagLib# was reporting the file was around 5s. Digging through the [ASF specification](https://hwiegman.home.xs4all.nl/fileformats/asf/ASF_Specification.pdf) and reading the sample with a hex editor, I found two issues with the TagLib# implementation:
1) The ASF File Properties Object (page 14 in the linked PDF) stores the play duration *before* the send duration. TagLib# is reading/writing the object the other way around, which means duration was calculated based on send duration (which in this case is a hundred milliseconds less than the play duration). This also means TagLib# is potentially corrupting ASF files by writing the send/play durations backwards. Fix for this is to swap the order play/send duration are read/written in the `FilePropertiesObject` class.
2) Preroll duration in the File Properties Object is stored in milliseconds. TagLib# is reading that value as 100ns ticks, so when it is subtracted from the play duration to calculate duration, it's subtracting a far smaller value than it should. Fix for this is to subtract a `TimeSpan` constructed from the preroll as milliseconds.

The issue described in #255 states that ASF spec says creation date in File Properties Object is 100ns ticks since 1/1/1601 instead of the C# `DateTime` format's 100ns ticks since 1/1/0000. I don't really know why this is the case, but it is what it is. The fix for this is to add the number of ticks for 1/1/1601 to the creation date as read from the file. ... However, after revisiting the code, I realized creation date is never used and it's impossible to get access to an instance of the class without manually re-reading it from the `AsfFile`, so this fix is more/less inconsequential. Nevertheless, it's bug, so I fix 😄. Unrelated, I'm planning to expose the `HeaderObject` in the `AsfFile` class in my port, and I'm thinking this would be a valuable addition to the TagLib# API.

**Testing**:
* Switched the ASF format tests from using the `StandardFileTests` properties test to checking all the properties we know about the sample file. All cases pass!