### PR TITLE
Added workaround for APE v1 where binary tags are treated as string

### DIFF
--- a/src/TaglibSharp/Ape/Item.cs
+++ b/src/TaglibSharp/Ape/Item.cs
@@ -466,10 +466,17 @@ namespace TagLib.Ape
 
 			Size = pos + 1 + (int)value_length - offset;
 
-			if (Type == ItemType.Binary)
-				this.data = new ReadOnlyByteVector (data.Mid (pos + 1, (int)value_length));
-			else
-				text = data.Mid (pos + 1, (int)value_length).ToStrings (StringType.UTF8, 0);
+			// Store both the binary and string representation, because APE v1. tags don't use the flags.
+			// Because of this the parser can't differentiate between string and binary. 
+			// In this case sting is assumed (because flags == 0).
+			//
+			// If we write both string and binary data, the application can still access the binary data by setting the Type to binary.            
+
+			// Binary representation
+			this.data = new ReadOnlyByteVector (data.Mid (pos + 1, (int)value_length));
+
+			// String representation
+			text = data.Mid (pos + 1, (int)value_length).ToStrings (StringType.UTF8, 0);
 		}
 
 		#endregion


### PR DESCRIPTION
Some applications still use APE v1 tags (such as Station Playlist, which is used by a lot of radio stations).

APE v1 does not use flags. Because of this, Taglib treats binary tags which were written by an application that uses APE v1 as strings. Even if it is really binary data.

This change fills both the data and text fields of an APE item.
The "normal flow" reading the text-field, because Type is still set to ItemType.Text.
However if the application knows that the item is really binary, it will be able to read it by setting Type to ItemType.Binary.
