### PR TITLE
Enhancements and Fixes for MusicBrainz Integration

### DIFF
--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -14,9 +14,9 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v1
     - name: Setup .NET Core
-      uses: actions/setup-dotnet@v3
+      uses: actions/setup-dotnet@v1
       with:
         dotnet-version: 6.0.302
     - name: Build with dotnet

--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -14,9 +14,9 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v3
     - name: Setup .NET Core
-      uses: actions/setup-dotnet@v1
+      uses: actions/setup-dotnet@v3
       with:
         dotnet-version: 6.0.302
     - name: Build with dotnet

--- a/src/TaglibSharp.Tests/FileFormats/M4aFormatTest.cs
+++ b/src/TaglibSharp.Tests/FileFormats/M4aFormatTest.cs
@@ -54,10 +54,10 @@ namespace TaglibSharp.Tests.FileFormats
 		[Test]
 		public void bgo_701689 ()
 		{
-			// This file contains a musicbrainz track id "883821fc-9bbc-4e04-be79-b4b12c4c4a4e"
+			// This file contains a musicbrainz recording id "883821fc-9bbc-4e04-be79-b4b12c4c4a4e"
 			// This case also handles bgo #701690 as a proper value for the tag must be returned
 			var file = TagLib.File.Create (TestPath.Samples + "bgo_701689.m4a");
-			Assert.AreEqual ("883821fc-9bbc-4e04-be79-b4b12c4c4a4e", file.Tag.MusicBrainzTrackId, "#1");
+			Assert.AreEqual ("883821fc-9bbc-4e04-be79-b4b12c4c4a4e", file.Tag.MusicBrainzRecordingId, "#1");
 		}
 
 		[Test]

--- a/src/TaglibSharp.Tests/TaggingFormats/ApeTest.cs
+++ b/src/TaglibSharp.Tests/TaggingFormats/ApeTest.cs
@@ -635,6 +635,56 @@ namespace TaglibSharp.Tests.TaggingFormats
 		}
 
 		[Test]
+		public void TestMusicBrainzRecordingID ()
+		{
+			Tag tag = new Tag ();
+
+			TagTestWithSave (ref tag, delegate (Tag t, string m) {
+				Assert.IsTrue (t.IsEmpty, "Initial (IsEmpty): " + m);
+				Assert.IsNull (t.MusicBrainzRecordingId, "Initial (Null): " + m);
+			});
+
+			tag.MusicBrainzRecordingId = val_sing;
+
+			TagTestWithSave (ref tag, delegate (Tag t, string m) {
+				Assert.IsFalse (t.IsEmpty, "Value Set (!IsEmpty): " + m);
+				Assert.AreEqual (val_sing, t.MusicBrainzRecordingId, "Value Set (!Null): " + m);
+			});
+
+			tag.MusicBrainzRecordingId = string.Empty;
+
+			TagTestWithSave (ref tag, delegate (Tag t, string m) {
+				Assert.IsTrue (t.IsEmpty, "Value Cleared (IsEmpty): " + m);
+				Assert.IsNull (t.MusicBrainzRecordingId, "Value Cleared (Null): " + m);
+			});
+		}
+
+		[Test]
+		public void TestMusicBrainzWorkID ()
+		{
+			Tag tag = new Tag ();
+
+			TagTestWithSave (ref tag, delegate (Tag t, string m) {
+				Assert.IsTrue (t.IsEmpty, "Initial (IsEmpty): " + m);
+				Assert.IsNull (t.MusicBrainzWorkId, "Initial (Null): " + m);
+			});
+
+			tag.MusicBrainzWorkId = val_sing;
+
+			TagTestWithSave (ref tag, delegate (Tag t, string m) {
+				Assert.IsFalse (t.IsEmpty, "Value Set (!IsEmpty): " + m);
+				Assert.AreEqual (val_sing, t.MusicBrainzWorkId, "Value Set (!Null): " + m);
+			});
+
+			tag.MusicBrainzWorkId = string.Empty;
+
+			TagTestWithSave (ref tag, delegate (Tag t, string m) {
+				Assert.IsTrue (t.IsEmpty, "Value Cleared (IsEmpty): " + m);
+				Assert.IsNull (t.MusicBrainzWorkId, "Value Cleared (Null): " + m);
+			});
+		}
+
+		[Test]
 		public void TestMusicBrainzDiscID ()
 		{
 			Tag tag = new Tag ();

--- a/src/TaglibSharp.Tests/TaggingFormats/AsfTest.cs
+++ b/src/TaglibSharp.Tests/TaggingFormats/AsfTest.cs
@@ -634,6 +634,56 @@ namespace TaglibSharp.Tests.TaggingFormats
 		}
 
 		[Test]
+		public void TestMusicBrainzRecordingID ()
+		{
+			var file = CreateFile (out var abst);
+
+			TagTestWithSave (ref file, abst, delegate (Tag t, string m) {
+				Assert.IsTrue (t.IsEmpty, "Initial (IsEmpty): " + m);
+				Assert.IsNull (t.MusicBrainzRecordingId, "Initial (Null): " + m);
+			});
+
+			file.Tag.MusicBrainzRecordingId = val_sing;
+
+			TagTestWithSave (ref file, abst, delegate (Tag t, string m) {
+				Assert.IsFalse (t.IsEmpty, "Value Set (!IsEmpty): " + m);
+				Assert.AreEqual (val_sing, t.MusicBrainzRecordingId, "Value Set (!Null): " + m);
+			});
+
+			file.Tag.MusicBrainzRecordingId = string.Empty;
+
+			TagTestWithSave (ref file, abst, delegate (Tag t, string m) {
+				Assert.IsTrue (t.IsEmpty, "Value Cleared (IsEmpty): " + m);
+				Assert.IsNull (t.MusicBrainzRecordingId, "Value Cleared (Null): " + m);
+			});
+		}
+
+		[Test]
+		public void TestMusicBrainzWorkID ()
+		{
+			var file = CreateFile (out var abst);
+
+			TagTestWithSave (ref file, abst, delegate (Tag t, string m) {
+				Assert.IsTrue (t.IsEmpty, "Initial (IsEmpty): " + m);
+				Assert.IsNull (t.MusicBrainzWorkId, "Initial (Null): " + m);
+			});
+
+			file.Tag.MusicBrainzWorkId = val_sing;
+
+			TagTestWithSave (ref file, abst, delegate (Tag t, string m) {
+				Assert.IsFalse (t.IsEmpty, "Value Set (!IsEmpty): " + m);
+				Assert.AreEqual (val_sing, t.MusicBrainzWorkId, "Value Set (!Null): " + m);
+			});
+
+			file.Tag.MusicBrainzWorkId = string.Empty;
+
+			TagTestWithSave (ref file, abst, delegate (Tag t, string m) {
+				Assert.IsTrue (t.IsEmpty, "Value Cleared (IsEmpty): " + m);
+				Assert.IsNull (t.MusicBrainzWorkId, "Value Cleared (Null): " + m);
+			});
+		}
+
+		[Test]
 		public void TestMusicBrainzDiscID ()
 		{
 			var file = CreateFile (out var abst);

--- a/src/TaglibSharp.Tests/TaggingFormats/Id3V2Test.cs
+++ b/src/TaglibSharp.Tests/TaggingFormats/Id3V2Test.cs
@@ -745,6 +745,62 @@ namespace TaglibSharp.Tests.TaggingFormats
 		}
 
 		[Test]
+		public void TestMusicBrainzRecordingID ()
+		{
+			var tag = new Tag ();
+			for (byte version = 2; version <= 4; version++) {
+				tag.Version = version;
+
+				TagTestWithSave (ref tag, delegate (Tag t, string m) {
+					Assert.IsTrue (t.IsEmpty, "Initial (IsEmpty): " + m);
+					Assert.IsNull (t.MusicBrainzRecordingId, "Initial (Null): " + m);
+				});
+
+				tag.MusicBrainzRecordingId = val_sing;
+
+				TagTestWithSave (ref tag, delegate (Tag t, string m) {
+					Assert.IsFalse (t.IsEmpty, "Value Set (!IsEmpty): " + m);
+					Assert.AreEqual (val_sing, t.MusicBrainzRecordingId, "Value Set (!Null): " + m);
+				});
+
+				tag.MusicBrainzRecordingId = string.Empty;
+
+				TagTestWithSave (ref tag, delegate (Tag t, string m) {
+					Assert.IsTrue (t.IsEmpty, "Value Cleared (IsEmpty): " + m);
+					Assert.IsNull (t.MusicBrainzRecordingId, "Value Cleared (Null): " + m);
+				});
+			}
+		}
+
+		[Test]
+		public void TestMusicBrainzWorkID ()
+		{
+			var tag = new Tag ();
+			for (byte version = 2; version <= 4; version++) {
+				tag.Version = version;
+
+				TagTestWithSave (ref tag, delegate (Tag t, string m) {
+					Assert.IsTrue (t.IsEmpty, "Initial (IsEmpty): " + m);
+					Assert.IsNull (t.MusicBrainzWorkId, "Initial (Null): " + m);
+				});
+
+				tag.MusicBrainzWorkId = val_sing;
+
+				TagTestWithSave (ref tag, delegate (Tag t, string m) {
+					Assert.IsFalse (t.IsEmpty, "Value Set (!IsEmpty): " + m);
+					Assert.AreEqual (val_sing, t.MusicBrainzWorkId, "Value Set (!Null): " + m);
+				});
+
+				tag.MusicBrainzWorkId = string.Empty;
+
+				TagTestWithSave (ref tag, delegate (Tag t, string m) {
+					Assert.IsTrue (t.IsEmpty, "Value Cleared (IsEmpty): " + m);
+					Assert.IsNull (t.MusicBrainzWorkId, "Value Cleared (Null): " + m);
+				});
+			}
+		}
+
+		[Test]
 		public void TestMusicBrainzDiscID ()
 		{
 			var tag = new Tag ();

--- a/src/TaglibSharp.Tests/TaggingFormats/Mpeg4Test.cs
+++ b/src/TaglibSharp.Tests/TaggingFormats/Mpeg4Test.cs
@@ -635,6 +635,56 @@ namespace TaglibSharp.Tests.TaggingFormats
 		}
 
 		[Test]
+		public void TestMusicBrainzRecordingID ()
+		{
+			var file = CreateFile (out var abst);
+
+			TagTestWithSave (ref file, abst, delegate (Tag t, string m) {
+				Assert.IsTrue (t.IsEmpty, "Initial (IsEmpty): " + m);
+				Assert.IsNull (t.MusicBrainzRecordingId, "Initial (Null): " + m);
+			});
+
+			file.Tag.MusicBrainzRecordingId = val_sing;
+
+			TagTestWithSave (ref file, abst, delegate (Tag t, string m) {
+				Assert.IsFalse (t.IsEmpty, "Value Set (!IsEmpty): " + m);
+				Assert.AreEqual (val_sing, t.MusicBrainzRecordingId, "Value Set (!Null): " + m);
+			});
+
+			file.Tag.MusicBrainzRecordingId = string.Empty;
+
+			TagTestWithSave (ref file, abst, delegate (Tag t, string m) {
+				Assert.IsTrue (t.IsEmpty, "Value Cleared (IsEmpty): " + m);
+				Assert.IsNull (t.MusicBrainzRecordingId, "Value Cleared (Null): " + m);
+			});
+		}
+
+		[Test]
+		public void TestMusicBrainzWorkID ()
+		{
+			var file = CreateFile (out var abst);
+
+			TagTestWithSave (ref file, abst, delegate (Tag t, string m) {
+				Assert.IsTrue (t.IsEmpty, "Initial (IsEmpty): " + m);
+				Assert.IsNull (t.MusicBrainzWorkId, "Initial (Null): " + m);
+			});
+
+			file.Tag.MusicBrainzWorkId = val_sing;
+
+			TagTestWithSave (ref file, abst, delegate (Tag t, string m) {
+				Assert.IsFalse (t.IsEmpty, "Value Set (!IsEmpty): " + m);
+				Assert.AreEqual (val_sing, t.MusicBrainzWorkId, "Value Set (!Null): " + m);
+			});
+
+			file.Tag.MusicBrainzWorkId = string.Empty;
+
+			TagTestWithSave (ref file, abst, delegate (Tag t, string m) {
+				Assert.IsTrue (t.IsEmpty, "Value Cleared (IsEmpty): " + m);
+				Assert.IsNull (t.MusicBrainzWorkId, "Value Cleared (Null): " + m);
+			});
+		}
+
+		[Test]
 		public void TestMusicBrainzDiscID ()
 		{
 			var file = CreateFile (out var abst);

--- a/src/TaglibSharp.Tests/TaggingFormats/XiphTest.cs
+++ b/src/TaglibSharp.Tests/TaggingFormats/XiphTest.cs
@@ -660,6 +660,56 @@ namespace TaglibSharp.Tests.TaggingFormats
 		}
 
 		[Test]
+		public void TestMusicBrainzRecordingID ()
+		{
+			var tag = new XiphComment ();
+
+			TagTestWithSave (ref tag, delegate (XiphComment t, string m) {
+				Assert.IsTrue (t.IsEmpty, "Initial (IsEmpty): " + m);
+				Assert.IsNull (t.MusicBrainzRecordingId, "Initial (Null): " + m);
+			});
+
+			tag.MusicBrainzRecordingId = val_sing;
+
+			TagTestWithSave (ref tag, delegate (XiphComment t, string m) {
+				Assert.IsFalse (t.IsEmpty, "Value Set (!IsEmpty): " + m);
+				Assert.AreEqual (val_sing, t.MusicBrainzRecordingId, "Value Set (!Null): " + m);
+			});
+
+			tag.MusicBrainzRecordingId = string.Empty;
+
+			TagTestWithSave (ref tag, delegate (XiphComment t, string m) {
+				Assert.IsTrue (t.IsEmpty, "Value Cleared (IsEmpty): " + m);
+				Assert.IsNull (t.MusicBrainzRecordingId, "Value Cleared (Null): " + m);
+			});
+		}
+
+		[Test]
+		public void TestMusicBrainzWorkID ()
+		{
+			var tag = new XiphComment ();
+
+			TagTestWithSave (ref tag, delegate (XiphComment t, string m) {
+				Assert.IsTrue (t.IsEmpty, "Initial (IsEmpty): " + m);
+				Assert.IsNull (t.MusicBrainzWorkId, "Initial (Null): " + m);
+			});
+
+			tag.MusicBrainzWorkId = val_sing;
+
+			TagTestWithSave (ref tag, delegate (XiphComment t, string m) {
+				Assert.IsFalse (t.IsEmpty, "Value Set (!IsEmpty): " + m);
+				Assert.AreEqual (val_sing, t.MusicBrainzWorkId, "Value Set (!Null): " + m);
+			});
+
+			tag.MusicBrainzWorkId = string.Empty;
+
+			TagTestWithSave (ref tag, delegate (XiphComment t, string m) {
+				Assert.IsTrue (t.IsEmpty, "Value Cleared (IsEmpty): " + m);
+				Assert.IsNull (t.MusicBrainzWorkId, "Value Cleared (Null): " + m);
+			});
+		}
+
+		[Test]
 		public void TestMusicBrainzDiscID ()
 		{
 			var tag = new XiphComment ();

--- a/src/TaglibSharp/Ape/Tag.cs
+++ b/src/TaglibSharp/Ape/Tag.cs
@@ -1420,12 +1420,46 @@ namespace TagLib.Ape
 		///    or <see langword="null" /> if no value is present.
 		/// </value>
 		/// <remarks>
-		///    This property is implemented using the "MUSICBRAINZ_TRACKID" item.
+		///    This property is implemented using the "MUSICBRAINZ_RELEASETRACKID" item.
 		///    http://musicbrainz.org/doc/PicardTagMapping
 		/// </remarks>
 		public override string MusicBrainzTrackId {
+			get { return GetItemAsString ("MUSICBRAINZ_RELEASETRACKID"); }
+			set { SetValue ("MUSICBRAINZ_RELEASETRACKID", value); }
+		}
+
+		/// <summary>
+		///    Gets and sets the MusicBrainz RecordingID
+		/// </summary>
+		/// <value>
+		///    A <see cref="string" /> containing the MusicBrainz
+		///    RecordingID for the media described by the current 
+		///    instance, or null if no value is present. 
+		/// </value>
+		/// <remarks>
+		///    This property is implemented using the "MUSICBRAINZ_TRACKID" frame.
+		///    http://musicbrainz.org/doc/PicardTagMapping
+		/// </remarks>
+		public override string MusicBrainzRecordingId {
 			get { return GetItemAsString ("MUSICBRAINZ_TRACKID"); }
 			set { SetValue ("MUSICBRAINZ_TRACKID", value); }
+		}
+
+		/// <summary>
+		///    Gets and sets the MusicBrainz WorkID
+		/// </summary>
+		/// <value>
+		///    A <see cref="string" /> containing the MusicBrainz
+		///    WorkID for the media described by the current 
+		///    instance, or null if no value is present. 
+		/// </value>
+		/// <remarks>
+		///    This property is implemented using the "MUSICBRAINZ_WORKID" frame.
+		///    http://musicbrainz.org/doc/PicardTagMapping
+		/// </remarks>
+		public override string MusicBrainzWorkId {
+			get { return GetItemAsString ("MUSICBRAINZ_WORKID"); }
+			set { SetValue ("MUSICBRAINZ_WORKID", value); }
 		}
 
 		/// <summary>

--- a/src/TaglibSharp/Asf/Tag.cs
+++ b/src/TaglibSharp/Asf/Tag.cs
@@ -1176,13 +1176,47 @@ namespace TagLib.Asf
 		///    instance or null if no value is present.
 		/// </value>
 		/// <remarks>
-		///    This property is implemented using the "MusicBrainz/Track Id"
+		///    This property is implemented using the "MusicBrainz/Release Track Id"
 		///    field.
 		///    http://musicbrainz.org/doc/PicardTagMapping
 		/// </remarks>
 		public override string MusicBrainzTrackId {
+			get { return GetDescriptorString ("MusicBrainz/Release Track Id"); }
+			set { SetDescriptorString (value, "MusicBrainz/Release Track Id"); }
+		}
+
+		/// <summary>
+		///    Gets and sets the MusicBrainz RecordingID
+		/// </summary>
+		/// <value>
+		///    A <see cref="string" /> containing the MusicBrainz
+		///    RecordingID for the media described by the current 
+		///    instance, or null if no value is present. 
+		/// </value>
+		/// <remarks>
+		///    This property is implemented using the "MusicBrainz/Track Id" field.
+		///    http://musicbrainz.org/doc/PicardTagMapping
+		/// </remarks>
+		public override string MusicBrainzRecordingId {
 			get { return GetDescriptorString ("MusicBrainz/Track Id"); }
 			set { SetDescriptorString (value, "MusicBrainz/Track Id"); }
+		}
+
+		/// <summary>
+		///    Gets and sets the MusicBrainz WorkID
+		/// </summary>
+		/// <value>
+		///    A <see cref="string" /> containing the MusicBrainz
+		///    WorkID for the media described by the current 
+		///    instance, or null if no value is present. 
+		/// </value>
+		/// <remarks>
+		///    This property is implemented using the "MusicBrainz/Work Id" field.
+		///    http://musicbrainz.org/doc/PicardTagMapping
+		/// </remarks>
+		public override string MusicBrainzWorkId {
+			get { return GetDescriptorString ("MusicBrainz/Work Id"); }
+			set { SetDescriptorString (value, "MusicBrainz/Work Id"); }
 		}
 
 		/// <summary>

--- a/src/TaglibSharp/CombinedTag.cs
+++ b/src/TaglibSharp/CombinedTag.cs
@@ -1408,6 +1408,82 @@ namespace TagLib
 						tag.MusicBrainzTrackId = value;
 			}
 		}
+		
+		/// <summary>
+		///    Gets and sets the MusicBrainz Recording ID.
+		/// </summary>
+		/// <value>
+		///    A <see cref="string" /> containing the MusicBrainz
+		///    RecordingID for the media described by the 
+		///    current instance or null if no value is present.
+		/// </value>
+		/// <remarks>
+		///    <para>When getting the value, the child tags are looped
+		///    through in order and the first non-<see langword="null" />
+		///    and non-empty value is returned.</para>
+		///    <para>When setting the value, it is stored in each child
+		///    tag.</para>
+		/// </remarks>
+		/// <seealso cref="Tag.MusicBrainzRecordingId" />
+		public override string MusicBrainzRecordingId {
+			get {
+				foreach (Tag tag in tags) {
+					if (tag == null)
+						continue;
+
+					string value = tag.MusicBrainzRecordingId;
+
+					if (value != null)
+						return value;
+				}
+
+				return null;
+			}
+
+			set {
+				foreach (Tag tag in tags)
+					if (tag != null)
+						tag.MusicBrainzRecordingId = value;
+			}
+		}
+
+		/// <summary>
+		///    Gets and sets the MusicBrainz Work ID.
+		/// </summary>
+		/// <value>
+		///    A <see cref="string" /> containing the MusicBrainz
+		///    WorkID for the media described by the 
+		///    current instance or null if no value is present.
+		/// </value>
+		/// <remarks>
+		///    <para>When getting the value, the child tags are looped
+		///    through in order and the first non-<see langword="null" />
+		///    and non-empty value is returned.</para>
+		///    <para>When setting the value, it is stored in each child
+		///    tag.</para>
+		/// </remarks>
+		/// <seealso cref="Tag.MusicBrainzWorkId" />
+		public override string MusicBrainzWorkId {
+			get {
+				foreach (Tag tag in tags) {
+					if (tag == null)
+						continue;
+
+					string value = tag.MusicBrainzWorkId;
+
+					if (value != null)
+						return value;
+				}
+
+				return null;
+			}
+
+			set {
+				foreach (Tag tag in tags)
+					if (tag != null)
+						tag.MusicBrainzWorkId = value;
+			}
+		}
 
 		/// <summary>
 		///    Gets and sets the MusicBrainz Disc ID.

--- a/src/TaglibSharp/Id3v2/Tag.cs
+++ b/src/TaglibSharp/Id3v2/Tag.cs
@@ -1973,12 +1973,46 @@ namespace TagLib.Id3v2
 		///    instance, or null if no value is present. 
 		/// </value>
 		/// <remarks>
-		///    This property is implemented using the "UFID:http://musicbrainz.org" frame.
+		///    This property is implemented using the "TXXX:MusicBrainz Release Track Id" frame.
 		///    http://musicbrainz.org/doc/PicardTagMapping
 		/// </remarks>
 		public override string MusicBrainzTrackId {
+			get { return GetUfidText ("MusicBrainz Release Track Id"); }
+			set { SetUfidText ("MusicBrainz Release Track Id", value); }
+		}
+
+		/// <summary>
+		///    Gets and sets the MusicBrainz RecordingID
+		/// </summary>
+		/// <value>
+		///    A <see cref="string" /> containing the MusicBrainz
+		///    RecordingID for the media described by the current 
+		///    instance, or null if no value is present. 
+		/// </value>
+		/// <remarks>
+		///    This property is implemented using the "UFID:http://musicbrainz.org" frame.
+		///    http://musicbrainz.org/doc/PicardTagMapping
+		/// </remarks>
+		public override string MusicBrainzRecordingId {
 			get { return GetUfidText ("http://musicbrainz.org"); }
 			set { SetUfidText ("http://musicbrainz.org", value); }
+		}
+
+		/// <summary>
+		///    Gets and sets the MusicBrainz WorkID
+		/// </summary>
+		/// <value>
+		///    A <see cref="string" /> containing the MusicBrainz
+		///    WorkID for the media described by the current 
+		///    instance, or null if no value is present. 
+		/// </value>
+		/// <remarks>
+		///    This property is implemented using the "TXXX:MusicBrainz Work Id" frame.
+		///    http://musicbrainz.org/doc/PicardTagMapping
+		/// </remarks>
+		public override string MusicBrainzWorkId {
+			get { return GetUfidText ("MusicBrainz Work Id"); }
+			set { SetUfidText ("MusicBrainz Work Id", value); }
 		}
 
 		/// <summary>

--- a/src/TaglibSharp/Mpeg4/AppleTag.cs
+++ b/src/TaglibSharp/Mpeg4/AppleTag.cs
@@ -1474,8 +1474,42 @@ namespace TagLib.Mpeg4
 		///    http://musicbrainz.org/doc/PicardTagMapping
 		/// </remarks>
 		public override string MusicBrainzTrackId {
+			get { return GetDashBox ("com.apple.iTunes", "MusicBrainz Release Track Id"); }
+			set { SetDashBox ("com.apple.iTunes", "MusicBrainz Release Track Id", value); }
+		}
+
+		/// <summary>
+		///    Gets and sets the MusicBrainz RecordingID
+		/// </summary>
+		/// <value>
+		///    A <see cref="string" /> containing the MusicBrainz
+		///    RecordingID for the media described by the current 
+		///    instance, or null if no value is present. 
+		/// </value>
+		/// <remarks>
+		///    This property is implemented using the "dash"/"----" box type.
+		///    http://musicbrainz.org/doc/PicardTagMapping
+		/// </remarks>
+		public override string MusicBrainzRecordingId {
 			get { return GetDashBox ("com.apple.iTunes", "MusicBrainz Track Id"); }
 			set { SetDashBox ("com.apple.iTunes", "MusicBrainz Track Id", value); }
+		}
+
+		/// <summary>
+		///    Gets and sets the MusicBrainz WorkID
+		/// </summary>
+		/// <value>
+		///    A <see cref="string" /> containing the MusicBrainz
+		///    WorkID for the media described by the current 
+		///    instance, or null if no value is present. 
+		/// </value>
+		/// <remarks>
+		///    This property is implemented using the "dash"/"----" box type.
+		///    http://musicbrainz.org/doc/PicardTagMapping
+		/// </remarks>
+		public override string MusicBrainzWorkId {
+			get { return GetDashBox ("com.apple.iTunes", "MusicBrainz Work Id"); }
+			set { SetDashBox ("com.apple.iTunes", "MusicBrainz Work Id", value); }
 		}
 
 		/// <summary>

--- a/src/TaglibSharp/Ogg/GroupedComment.cs
+++ b/src/TaglibSharp/Ogg/GroupedComment.cs
@@ -1111,6 +1111,66 @@ namespace TagLib.Ogg
 		}
 
 		/// <summary>
+		///    Gets and sets the MusicBrainz Recording ID.
+		/// </summary>
+		/// <value>
+		///    A <see cref="string" /> containing the MusicBrainz
+		///    RecordingID for the media described by the 
+		///    current instance or null if no value is present.
+		/// </value>
+		/// <remarks>
+		///    <para>When getting the value, the child comments are looped
+		///    through in order and the first non-<see langword="null" />
+		///    and non-empty value is returned.</para>
+		///    <para>When setting the value, it is stored in the first
+		///    comment.</para>
+		/// </remarks>
+		/// <seealso cref="Tag.MusicBrainzRecordingId" />
+		public override string MusicBrainzRecordingId {
+			get {
+				foreach (XiphComment tag in tags) {
+					string value = tag?.MusicBrainzRecordingId;
+
+					if (!string.IsNullOrEmpty (value))
+						return value;
+				}
+
+				return null;
+			}
+			set { if (tags.Count > 0) tags[0].MusicBrainzRecordingId = value; }
+		}
+
+		/// <summary>
+		///    Gets and sets the MusicBrainz Work ID.
+		/// </summary>
+		/// <value>
+		///    A <see cref="string" /> containing the MusicBrainz
+		///    WorkID for the media described by the 
+		///    current instance or null if no value is present.
+		/// </value>
+		/// <remarks>
+		///    <para>When getting the value, the child comments are looped
+		///    through in order and the first non-<see langword="null" />
+		///    and non-empty value is returned.</para>
+		///    <para>When setting the value, it is stored in the first
+		///    comment.</para>
+		/// </remarks>
+		/// <seealso cref="Tag.MusicBrainzWorkId" />
+		public override string MusicBrainzWorkId {
+			get {
+				foreach (XiphComment tag in tags) {
+					string value = tag?.MusicBrainzWorkId;
+
+					if (!string.IsNullOrEmpty (value))
+						return value;
+				}
+
+				return null;
+			}
+			set { if (tags.Count > 0) tags[0].MusicBrainzWorkId = value; }
+		}
+
+		/// <summary>
 		///    Gets and sets the MusicBrainz Disc ID.
 		/// </summary>
 		/// <value>

--- a/src/TaglibSharp/Ogg/XiphComment.cs
+++ b/src/TaglibSharp/Ogg/XiphComment.cs
@@ -1291,11 +1291,45 @@ namespace TagLib.Ogg
 		///    instance or <see langword="null" /> if no value present.
 		/// </value>
 		/// <remarks>
-		///    This property is implemented using the "MUSICBRAINZ_TRACKID" field.
+		///    This property is implemented using the "MUSICBRAINZ_RELEASETRACKID" field.
 		/// </remarks>
 		public override string MusicBrainzTrackId {
+			get { return GetFirstField ("MUSICBRAINZ_RELEASETRACKID"); }
+			set { SetField ("MUSICBRAINZ_RELEASETRACKID", value); }
+		}
+
+		/// <summary>
+		///    Gets and sets the MusicBrainz Recording ID for the media
+		///    represented by the current instance.
+		/// </summary>
+		/// <value>
+		///    A <see cref="string" /> object containing the MusicBrainz
+		///    RecordingID for the media represented by the current
+		///    instance or <see langword="null" /> if no value present.
+		/// </value>
+		/// <remarks>
+		///    This property is implemented using the "MUSICBRAINZ_TRACKID" field.
+		/// </remarks>
+		public override string MusicBrainzRecordingId {
 			get { return GetFirstField ("MUSICBRAINZ_TRACKID"); }
 			set { SetField ("MUSICBRAINZ_TRACKID", value); }
+		}
+
+		/// <summary>
+		///    Gets and sets the MusicBrainz Work ID for the media
+		///    represented by the current instance.
+		/// </summary>
+		/// <value>
+		///    A <see cref="string" /> object containing the MusicBrainz
+		///    WorkID for the media represented by the current
+		///    instance or <see langword="null" /> if no value present.
+		/// </value>
+		/// <remarks>
+		///    This property is implemented using the "MUSICBRAINZ_WORKID" field.
+		/// </remarks>
+		public override string MusicBrainzWorkId {
+			get { return GetFirstField ("MUSICBRAINZ_WORKID"); }
+			set { SetField ("MUSICBRAINZ_WORKID", value); }
 		}
 
 		/// <summary>

--- a/src/TaglibSharp/Tag.cs
+++ b/src/TaglibSharp/Tag.cs
@@ -849,6 +849,42 @@ namespace TagLib
 		}
 
 		/// <summary>
+		///    Gets and sets the MusicBrainz Recording ID of the media represented by
+		///    the current instance.
+		/// </summary>
+		/// <value>
+		///    A <see cref="string" /> containing the MusicBrainz RecordingID of the
+		///    media represented by the current instance or an empty
+		///    array if no value is present.
+		/// </value>
+		/// <remarks>
+		///    <para>This field represents the MusicBrainz RecordingID, and is used
+		///    to uniquely identify a particular recording.</para>
+		/// </remarks>
+		public virtual string MusicBrainzRecordingId {
+			get { return null; }
+			set { }
+		}
+
+		/// <summary>
+		///    Gets and sets the MusicBrainz Work ID of the media represented by
+		///    the current instance.
+		/// </summary>
+		/// <value>
+		///    A <see cref="string" /> containing the MusicBrainz WorkID of the
+		///    media represented by the current instance or an empty
+		///    array if no value is present.
+		/// </value>
+		/// <remarks>
+		///    <para>This field represents the MusicBrainz WorkID, and is used
+		///    to uniquely identify a particular work.</para>
+		/// </remarks>
+		public virtual string MusicBrainzWorkId {
+			get { return null; }
+			set { }
+		}
+
+		/// <summary>
 		///    Gets and sets the MusicBrainz Disc ID of the media represented by
 		///    the current instance.
 		/// </summary>


### PR DESCRIPTION
This PR adds two new MusicBrainz tags and fixes one MusicBrainz tag that used the wrong frame.

- Fixes #304
- Add MusicBrainzRecordingId
- Add MusicBrainzWorkId

This basically means the following:

MusicBrainzRecordingId returns the value that was previously returned by MusicBrainzTrackId.
MusicBrainzTrackId now returns the correct frame data.
MusicBrainzWorkId added to return its frame data.

I used the following documentation: https://picard-docs.musicbrainz.org/downloads/MusicBrainz_Picard_Tag_Map.html