### PR TITLE
Remove TAGLIB# DEBUG line when reading XMP tags

### DIFF
--- a/src/TaglibSharp/Xmp/XmpTag.cs
+++ b/src/TaglibSharp/Xmp/XmpTag.cs
@@ -1022,7 +1022,6 @@ namespace TagLib.Xmp
 		{
 			if (!NamespacePrefixes.ContainsKey (ns)) {
 				NamespacePrefixes.Add (ns, $"ns{++anon_ns_count}");
-				Console.WriteLine ("TAGLIB# DEBUG: Added {0} prefix for {1} namespace (XMP)", NamespacePrefixes[ns], ns);
 			}
 		}
 


### PR DESCRIPTION
A `TAGLIB# DEBUG: Added ns1 prefix for...` line is written to the console when XMP tags are encountered. This is seemingly a leftover debug line and cannot be turned off, interfering with software that uses the standard output to write data.