### PR TITLE
Fix culture-sensitive BPM parsing

### DIFF
--- a/src/TaglibSharp/Ape/Tag.cs
+++ b/src/TaglibSharp/Ape/Tag.cs
@@ -1265,8 +1265,10 @@ namespace TagLib.Ape
 					return 0;
 
 
-				if (double.TryParse (text, out var value))
+				if (double.TryParse (text, NumberStyles.Float, CultureInfo.InvariantCulture,
+					out var value)) {
 					return (uint)Math.Round (value);
+				}
 
 				return 0;
 			}

--- a/src/TaglibSharp/Id3v2/Tag.cs
+++ b/src/TaglibSharp/Id3v2/Tag.cs
@@ -1819,8 +1819,10 @@ namespace TagLib.Id3v2
 				if (text == null)
 					return 0;
 
-				if (double.TryParse (text, out var result) && result >= 0.0)
+				if (double.TryParse (text, NumberStyles.Float, CultureInfo.InvariantCulture,
+					out var result) && result >= 0.0) {
 					return (uint)Math.Round (result);
+				}
 
 				return 0;
 			}


### PR DESCRIPTION
Prevents a BPM tag like "123.45" from getting parsed as "12345" if a locale with `,` as decimal separator is used. Fixes #236.