### PR TITLE
Add ability to enable Read Sharing when Writing to files

### DIFF
--- a/examples/ReadFromUri/ReadFromUri.cs
+++ b/examples/ReadFromUri/ReadFromUri.cs
@@ -136,6 +136,11 @@ public class FileAbstraction : TagLib.File.IFileAbstraction
 
 	public Stream WriteStream => new FileStream (Name, FileMode.Open);
 
+	public bool ReadShareWhenWriting {
+		get => throw new NotSupportedException ();
+		set => throw new NotSupportedException ();
+	}
+
 	public void CloseStream (Stream stream)
 	{
 		stream.Close ();

--- a/src/TaglibSharp.Tests/Helpers.cs
+++ b/src/TaglibSharp.Tests/Helpers.cs
@@ -78,6 +78,11 @@ namespace TaglibSharp.Tests
 
 		public Stream WriteStream => stream;
 
+		public bool ReadShareWhenWriting {
+			get => throw new NotSupportedException ();
+			set => throw new NotSupportedException ();
+		}
+
 		public void CloseStream (Stream stream)
 		{
 			// This causes a stackoverflow

--- a/src/TaglibSharp/File.cs
+++ b/src/TaglibSharp/File.cs
@@ -189,6 +189,12 @@ namespace TagLib
 		/// </summary>
 		List<string> corruption_reasons;
 
+		/// <summary>
+		///    Specifies whether the file should be readable by other
+		///    threads while being written to by the thread that opened it.
+		/// </summary>
+		public bool read_share_when_writing;
+
 		#endregion
 
 
@@ -1621,7 +1627,15 @@ namespace TagLib
 			/// </value>
 			public Stream WriteStream => System.IO.File.Open (Name,
 				FileMode.Open,
-				FileAccess.ReadWrite);
+				FileAccess.ReadWrite,
+				ReadShareWhenWriting ? FileShare.Read : FileShare.None);
+
+			/// <summary>
+			///    Gets or sets a value indicating whether the file should
+			///    be readable by other threads while being written to by
+			///    the thread that opened it.
+			/// </summary>
+			public bool ReadShareWhenWriting { get; set; }
 
 			/// <summary>
 			///    Closes a stream created by the current instance.
@@ -1792,6 +1806,19 @@ namespace TagLib
 			///    way to keep it open.
 			/// </remarks>
 			Stream WriteStream { get; }
+
+			/// <summary>
+			///    Gets or sets a value indicating whether the file
+			///    should be readable by other threads while being
+			///    written to by the thread that opened it.
+			/// </summary>
+			/// <remarks>
+			///    This property is useful when editing ID3 tags of
+			///    MP3 files.  In particular, setting it to true
+			///    ensures you can listen to a song in one application
+			///    while simultaneously editing its ID3 tags in another.
+			/// </remarks>
+			bool ReadShareWhenWriting { get; set; }
 
 			/// <summary>
 			///    Closes a stream originating from the current

--- a/src/TaglibSharp/Tiff/Rw2/IFDReader.cs
+++ b/src/TaglibSharp/Tiff/Rw2/IFDReader.cs
@@ -21,6 +21,7 @@
 // USA
 //
 
+using System;
 using System.IO;
 using TagLib.IFD;
 
@@ -132,6 +133,11 @@ namespace TagLib.Tiff.Rw2
 
 		public Stream WriteStream {
 			get { return ReadStream; }
+		}
+
+		public bool ReadShareWhenWriting {
+			get => throw new NotSupportedException ();
+			set => throw new NotSupportedException ();
 		}
 	}
 }


### PR DESCRIPTION
### What
This change adds a new `LocalFileAbstraction.ReadShareWhenWriting` property.  By default, this property is `false`, resulting in no change in code flow.  If a library user chooses to optionally enable it, then the `WriteStream` created by `LocalFileAbstraction` will use `FileShare.Read`, meaning that other processes can continue to read the file while it is being written to.

Currently, this change is only needed/useful when working with MP3 files.  It will throw a `NotSupportedException()` if used anywhere else.

### Why
A common scenario when editing ID3 tags is that a user uses one application (something like Mp3tag) to edit tags, while they use another application (something like WinAmp) to simultaneously listen to the MP3 files for which tags are being edited.  This scenario works perfectly fine with most application mixes like the ones mentioned above.  The only "side-effect" is a slight audio glitch that occurs after the tag of a playing song gets updated.

Using the example applications mentioned above, if Mp3tag were to be implemented using `taglib-sharp`, the above scenario no longer becomes possible.  A user plays a song to determine what Genre it should be.  Then, while they continue to listen to the song, they attempt to set the Genre in its ID3 tag.  But they can't, because the MP3 file is already in use.

### How Tested?
- The scenario mentioned above didn't work before, now it does.
- A new unit test was created to cover this new property.